### PR TITLE
#604 - Changed AEM Component Sling Model interfaces from @ProviderTyp…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+#604 - Changed AEM Component Sling Model interfaces from @ProviderType to @ConsumerType for extensibility (see Github issue #604 for details)
+
 ## [v2.0.2]
 
 ### Fixed

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/cart/Cart.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/cart/Cart.java
@@ -20,11 +20,11 @@
 package com.adobe.aem.commons.assetshare.components.actions.cart;
 
 import com.adobe.aem.commons.assetshare.content.AssetModel;
-import org.osgi.annotation.versioning.ProviderType;
+import org.osgi.annotation.versioning.ConsumerType;
 
 import java.util.Collection;
 
-@ProviderType
+@ConsumerType
 public interface Cart {
     Collection<AssetModel> getAssets();
 

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/cart/package-info.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/cart/package-info.java
@@ -17,7 +17,7 @@
  *
  */
 
-@Version("1.0.0")
+@Version("1.0.1")
 package com.adobe.aem.commons.assetshare.components.actions.cart;
 
 import org.osgi.annotation.versioning.Version;

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/download/Download.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/download/Download.java
@@ -23,7 +23,7 @@ import com.adobe.aem.commons.assetshare.content.AssetModel;
 import com.adobe.cq.wcm.core.components.models.form.OptionItem;
 import com.adobe.cq.wcm.core.components.models.form.Options;
 import com.google.common.collect.ImmutableList;
-import org.osgi.annotation.versioning.ProviderType;
+import org.osgi.annotation.versioning.ConsumerType;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -33,7 +33,7 @@ import java.util.List;
 /**
  * The model interface that represents the Download action component.
  */
-@ProviderType
+@ConsumerType
 public interface Download {
     /**
      * @return a collection of assets that are to be downloaded.

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/download/package-info.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/download/package-info.java
@@ -17,7 +17,7 @@
  *
  */
 
-@Version("1.2.0")
+@Version("1.2.1")
 package com.adobe.aem.commons.assetshare.components.actions.download;
 
 import org.osgi.annotation.versioning.Version;

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/downloads/Downloads.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/downloads/Downloads.java
@@ -3,11 +3,11 @@ package com.adobe.aem.commons.assetshare.components.actions.downloads;
 import com.adobe.aem.commons.assetshare.content.renditions.download.async.DownloadEntry;
 import com.adobe.cq.dam.download.api.DownloadException;
 import com.adobe.cq.dam.download.api.DownloadProgress;
-import org.osgi.annotation.versioning.ProviderType;
+import org.osgi.annotation.versioning.ConsumerType;
 
 import java.util.List;
 
-@ProviderType
+@ConsumerType
 public interface Downloads {
 
 	/**

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/downloads/package-info.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/downloads/package-info.java
@@ -17,7 +17,7 @@
  *
  */
 
-@Version("1.0.0")
+@Version("1.0.1")
 package com.adobe.aem.commons.assetshare.components.actions.downloads;
 
 import org.osgi.annotation.versioning.Version;

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/share/EmailShare.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/share/EmailShare.java
@@ -20,9 +20,9 @@
 package com.adobe.aem.commons.assetshare.components.actions.share;
 
 import org.apache.sling.api.resource.ValueMap;
-import org.osgi.annotation.versioning.ProviderType;
+import org.osgi.annotation.versioning.ConsumerType;
 
-@ProviderType
+@ConsumerType
 public interface EmailShare extends Share {
 
     String PN_SIGNATURE = "signature";

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/share/Share.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/share/Share.java
@@ -20,11 +20,11 @@
 package com.adobe.aem.commons.assetshare.components.actions.share;
 
 import com.adobe.aem.commons.assetshare.content.AssetModel;
-import org.osgi.annotation.versioning.ProviderType;
+import org.osgi.annotation.versioning.ConsumerType;
 
 import java.util.Collection;
 
-@ProviderType
+@ConsumerType
 public interface Share {
     Collection<AssetModel> getAssets();
 

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/share/package-info.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/share/package-info.java
@@ -17,7 +17,7 @@
  *
  */
 
-@Version("2.1.0")
+@Version("2.1.1")
 package com.adobe.aem.commons.assetshare.components.actions.share;
 
 import org.osgi.annotation.versioning.Version;

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/ActionButtons.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/ActionButtons.java
@@ -19,5 +19,8 @@
 
 package com.adobe.aem.commons.assetshare.components.details;
 
+import org.osgi.annotation.versioning.ConsumerType;
+
+@ConsumerType
 public interface ActionButtons extends EmptyTextComponent {
 }

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/EditorLinks.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/EditorLinks.java
@@ -19,9 +19,9 @@
 
 package com.adobe.aem.commons.assetshare.components.details;
 
-import org.osgi.annotation.versioning.ProviderType;
+import org.osgi.annotation.versioning.ConsumerType;
 
-@ProviderType
+@ConsumerType
 public interface EditorLinks extends EmptyTextComponent {
     String getAssetFolderEditorPath();
 

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/EmptyTextComponent.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/EmptyTextComponent.java
@@ -20,7 +20,9 @@
 package com.adobe.aem.commons.assetshare.components.details;
 
 import com.adobe.aem.commons.assetshare.components.Component;
+import org.osgi.annotation.versioning.ConsumerType;
 
+@ConsumerType
 public interface EmptyTextComponent extends Component {
 
     boolean isEmpty();

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/Image.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/Image.java
@@ -19,6 +19,9 @@
 
 package com.adobe.aem.commons.assetshare.components.details;
 
+import org.osgi.annotation.versioning.ConsumerType;
+
+@ConsumerType
 public interface Image extends EmptyTextComponent {
     String getSrc();
 

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/Renditions.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/Renditions.java
@@ -20,11 +20,11 @@
 package com.adobe.aem.commons.assetshare.components.details;
 
 import com.adobe.aem.commons.assetshare.content.Rendition;
-import org.osgi.annotation.versioning.ProviderType;
+import org.osgi.annotation.versioning.ConsumerType;
 
 import java.util.Collection;
 
-@ProviderType
+@ConsumerType
 public interface Renditions extends EmptyTextComponent {
     Collection<Rendition> getRenditions();
 

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/Tags.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/Tags.java
@@ -20,6 +20,7 @@
 package com.adobe.aem.commons.assetshare.components.details;
 
 import java.util.List;
+import org.osgi.annotation.versioning.ConsumerType;
 
 public interface Tags extends EmptyTextComponent {
     /***

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/Title.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/Title.java
@@ -19,6 +19,9 @@
 
 package com.adobe.aem.commons.assetshare.components.details;
 
+import org.osgi.annotation.versioning.ConsumerType;
+
+@ConsumerType
 public interface Title extends EmptyTextComponent {
     /***
      * @return a string to display as the title of the asset.

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/Video.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/Video.java
@@ -1,13 +1,14 @@
 package com.adobe.aem.commons.assetshare.components.details;
 
 import org.osgi.annotation.versioning.ProviderType;
+import org.osgi.annotation.versioning.ConsumerType;
 
 /**
  *
  * Interface for Video Component
  *
  */
-@ProviderType
+@ConsumerType
 public interface Video extends EmptyTextComponent {
     /**
      * @return Returns src

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/package-info.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/package-info.java
@@ -14,7 +14,7 @@
  *
  */
 
-@Version("1.3.0")
+@Version("1.3.1")
 package com.adobe.aem.commons.assetshare.components.details;
 
 import org.osgi.annotation.versioning.Version;

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/DatePredicate.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/DatePredicate.java
@@ -20,11 +20,11 @@
 package com.adobe.aem.commons.assetshare.components.predicates;
 
 import com.adobe.cq.wcm.core.components.models.form.OptionItem;
-import org.osgi.annotation.versioning.ProviderType;
+import org.osgi.annotation.versioning.ConsumerType;
 
 import java.util.List;
 
-@ProviderType
+@ConsumerType
 public interface DatePredicate extends Predicate {
 
     String getLowerBoundName();

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/FreeformTextPredicate.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/FreeformTextPredicate.java
@@ -1,10 +1,10 @@
 package com.adobe.aem.commons.assetshare.components.predicates;
 
-import org.osgi.annotation.versioning.ProviderType;
+import org.osgi.annotation.versioning.ConsumerType;
 
 import java.util.List;
 
-@ProviderType
+@ConsumerType
 public interface FreeformTextPredicate extends Predicate {
     /**
      * @return the predicate title.

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/FulltextPredicate.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/FulltextPredicate.java
@@ -20,8 +20,8 @@
 package com.adobe.aem.commons.assetshare.components.predicates;
 
 import com.adobe.cq.wcm.core.components.models.form.Text;
-import org.osgi.annotation.versioning.ProviderType;
+import org.osgi.annotation.versioning.ConsumerType;
 
-@ProviderType
+@ConsumerType
 public interface FulltextPredicate extends Text {
 }

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/HiddenPredicate.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/HiddenPredicate.java
@@ -20,11 +20,11 @@
 package com.adobe.aem.commons.assetshare.components.predicates;
 
 import com.day.cq.search.PredicateGroup;
-import org.osgi.annotation.versioning.ProviderType;
+import org.osgi.annotation.versioning.ConsumerType;
 
 import java.util.Map;
 
-@ProviderType
+@ConsumerType
 public interface HiddenPredicate extends Predicate {
     /**
      * @return a PredicateGroup that represents the HiddenPredicate configuration.

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/PagePredicate.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/PagePredicate.java
@@ -20,7 +20,7 @@
 package com.adobe.aem.commons.assetshare.components.predicates;
 
 import com.day.cq.search.PredicateGroup;
-import org.osgi.annotation.versioning.ProviderType;
+import org.osgi.annotation.versioning.ConsumerType;
 
 import java.util.List;
 import java.util.Map;
@@ -31,7 +31,7 @@ import java.util.Map;
  * This is called PagePredicate as these values can come from multiple components across the Search page, however
  * most are sourced from the Search Results component.
  */
-@ProviderType
+@ConsumerType
 public interface PagePredicate extends Predicate {
     /**
      * The QB parameter types that getPredicateGroup(..) can build (or ask it to not build).

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/PathPredicate.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/PathPredicate.java
@@ -21,11 +21,11 @@ package com.adobe.aem.commons.assetshare.components.predicates;
 
 import com.adobe.cq.wcm.core.components.models.form.OptionItem;
 import com.adobe.cq.wcm.core.components.models.form.Options;
-import org.osgi.annotation.versioning.ProviderType;
+import org.osgi.annotation.versioning.ConsumerType;
 
 import java.util.List;
 
-@ProviderType
+@ConsumerType
 public interface PathPredicate extends Predicate {
 
     /**

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/PropertyPredicate.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/PropertyPredicate.java
@@ -21,11 +21,11 @@ package com.adobe.aem.commons.assetshare.components.predicates;
 
 import com.adobe.cq.wcm.core.components.models.form.OptionItem;
 import com.adobe.cq.wcm.core.components.models.form.Options;
-import org.osgi.annotation.versioning.ProviderType;
+import org.osgi.annotation.versioning.ConsumerType;
 
 import java.util.List;
 
-@ProviderType
+@ConsumerType
 public interface PropertyPredicate extends Predicate {
 
     /**

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/SortPredicate.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/SortPredicate.java
@@ -20,11 +20,11 @@
 package com.adobe.aem.commons.assetshare.components.predicates;
 
 import com.adobe.cq.wcm.core.components.models.form.OptionItem;
-import org.osgi.annotation.versioning.ProviderType;
+import org.osgi.annotation.versioning.ConsumerType;
 
 import java.util.List;
 
-@ProviderType
+@ConsumerType
 public interface SortPredicate extends Predicate {
     /**
      * @return the option items for this predicate.

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/TagsPredicate.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/TagsPredicate.java
@@ -19,9 +19,9 @@
 
 package com.adobe.aem.commons.assetshare.components.predicates;
 
-import org.osgi.annotation.versioning.ProviderType;
+import org.osgi.annotation.versioning.ConsumerType;
 
-@ProviderType
+@ConsumerType
 public interface TagsPredicate extends PropertyPredicate {
 
     // TagsPredicate is a special case (impl details) of the PropertyPredicate.

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/package-info.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/package-info.java
@@ -17,7 +17,7 @@
  *
  */
 
-@Version("4.0.0")
+@Version("4.0.1")
 package com.adobe.aem.commons.assetshare.components.predicates;
 
 import org.osgi.annotation.versioning.Version;

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/search/SearchConfig.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/search/SearchConfig.java
@@ -2,7 +2,7 @@ package com.adobe.aem.commons.assetshare.components.search;
 
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
-import org.osgi.annotation.versioning.ProviderType;
+import org.osgi.annotation.versioning.ConsumerType;
 
 import java.util.Collections;
 import java.util.List;
@@ -14,7 +14,7 @@ import java.util.List;
  *
  * This class should not take into account HTTP-provided parameters, but rather deal directly with the resource content.
  */
-@ProviderType
+@ConsumerType
 public interface SearchConfig {
     /**
      * @return the resource that represents the Search Component resource.

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/search/Statistics.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/search/Statistics.java
@@ -1,12 +1,12 @@
 package com.adobe.aem.commons.assetshare.components.search;
 
 import com.adobe.aem.commons.assetshare.components.Component;
-import org.osgi.annotation.versioning.ProviderType;
+import org.osgi.annotation.versioning.ConsumerType;
 
 /**
  * Sling Model for the Search Statistics Component.
  */
-@ProviderType
+@ConsumerType
 public interface Statistics extends Component {
     /**
      * @return the component id; unique to this instance of the component.

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/search/package-info.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/search/package-info.java
@@ -17,7 +17,7 @@
  *
  */
 
-@Version("2.1.0")
+@Version("2.1.1")
 package com.adobe.aem.commons.assetshare.components.search;
 
 import org.osgi.annotation.versioning.Version;

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/structure/Header.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/structure/Header.java
@@ -22,9 +22,11 @@ package com.adobe.aem.commons.assetshare.components.structure;
 import com.adobe.aem.commons.assetshare.components.Component;
 import com.day.cq.commons.jcr.JcrConstants;
 import com.day.cq.wcm.api.Page;
+import org.osgi.annotation.versioning.ConsumerType;
 
 import java.util.Collection;
 
+@ConsumerType
 public interface Header extends Component {
 
     /**

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/structure/UserMenu.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/structure/UserMenu.java
@@ -20,7 +20,9 @@
 package com.adobe.aem.commons.assetshare.components.structure;
 
 import com.adobe.aem.commons.assetshare.components.Component;
+import org.osgi.annotation.versioning.ConsumerType;
 
+@ConsumerType
 public interface UserMenu extends Component {
 
 }

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/structure/package-info.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/structure/package-info.java
@@ -17,7 +17,7 @@
  *
  */
 
-@Version("2.0.0")
+@Version("2.0.1")
 package com.adobe.aem.commons.assetshare.components.structure;
 
 import org.osgi.annotation.versioning.Version;


### PR DESCRIPTION
## Description

Changed AEM Component Sling Model interfaces from @ProviderTyee to @ConsumerType for extensibility.

Listing as a build version bump (2.0.4) as this doesnt really add any specific new functionality, and package-java version bumps were also to builf version.

## Motivation and Context

See details of the request in #604 

## How Has This Been Tested?

AEM SDK

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue). 
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
