### PR TITLE
#643 - Site title shows up the component policy title if not authored…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed 
+
+- 0643 - Site title shows up the component policy title if not authored on header component policy
+
 ## [v2.1.4]
 
 ### Fixed

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/structure/Header.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/structure/Header.java
@@ -42,7 +42,7 @@ public interface Header extends Component {
     /**
      * property in which a site title is stored.
      */
-    String PN_SITE_TITLE = JcrConstants.JCR_TITLE;
+    String PN_SITE_TITLE = "title";
 
     /**
      * Name of the node relative to the header component that stores the pages and icon items.

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/structure/impl/HeaderImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/structure/impl/HeaderImpl.java
@@ -22,10 +22,11 @@ package com.adobe.aem.commons.assetshare.components.structure.impl;
 import com.adobe.aem.commons.assetshare.components.structure.Header;
 import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.export.json.ExporterConstants;
+import com.day.cq.commons.jcr.JcrConstants;
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.PageManager;
 import com.day.cq.wcm.api.designer.Style;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
@@ -198,6 +199,11 @@ public class HeaderImpl implements Header {
     public String getSiteTitle() {
         if (siteTitle == null) {
             siteTitle = getHeaderProperty(PN_SITE_TITLE);
+        }
+
+        // Check old property name for backwards compatibility
+        if (siteTitle == null) {
+            siteTitle = getHeaderProperty(JcrConstants.JCR_TITLE);
         }
 
         return siteTitle;

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/structure/package-info.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/structure/package-info.java
@@ -17,7 +17,7 @@
  *
  */
 
-@Version("2.0.1")
+@Version("2.0.2")
 package com.adobe.aem.commons.assetshare.components.structure;
 
 import org.osgi.annotation.versioning.Version;

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/structure/header/_cq_design_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/structure/header/_cq_design_dialog/.content.xml
@@ -61,7 +61,7 @@
                                     fieldDescription="Please use the Site Title field defined above."
                                     fieldLabel="Site Title (Legacy field)"
                                     emptyText="Please use the Site Title field above."
-                                    disabled="{Boolean}true"
+                                    disabled="{Boolean}false"
                                     name="./jcr:title"/>
                         </items>
                     </branding>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/structure/header/_cq_design_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/structure/header/_cq_design_dialog/.content.xml
@@ -58,9 +58,9 @@
                             <site-title-legacy
                                     jcr:primaryType="nt:unstructured"
                                     sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
-                                    fieldDescription="Please use the Site Title field defined above."
+                                    fieldDescription="Do not use this field. Please use the Site Title field defined above."
                                     fieldLabel="Site Title (Legacy field)"
-                                    emptyText="Please use the Site Title field above."
+                                    emptyText="Do not use this field. Please use the Site Title field above."
                                     disabled="{Boolean}false"
                                     name="./jcr:title"/>
                         </items>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/structure/header/_cq_design_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/structure/header/_cq_design_dialog/.content.xml
@@ -53,6 +53,15 @@
                                     jcr:primaryType="nt:unstructured"
                                     sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                     fieldLabel="Site Title"
+                                    name="./title"/>
+
+                            <site-title-legacy
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                    fieldDescription="Please use the Site Title field defined above."
+                                    fieldLabel="Site Title (Legacy field)"
+                                    emptyText="Please use the Site Title field above."
+                                    disabled="{Boolean}true"
                                     name="./jcr:title"/>
                         </items>
                     </branding>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/structure/header/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/structure/header/_cq_dialog/.content.xml
@@ -57,7 +57,8 @@
                                             jcr:primaryType="nt:unstructured"
                                             sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                             fieldLabel="Site Title"
-                                            name="./jcr:title"/>
+                                            name="./title"/>
+
                                     <home-page-path
                                             jcr:primaryType="nt:unstructured"
                                             sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
@@ -65,6 +66,15 @@
                                             fieldLabel="Home Page Path"
                                             name="./rootPath"
                                             rootPath="/content"/>
+
+                                    <site-title-legacy
+                                            jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                            fieldDescription="Please use the Site Title field defined above."
+                                            fieldLabel="Site Title (Legacy field)"
+                                            emptyText="Please use the Site Title field above."
+                                            disabled="{Boolean}true"
+                                            name="./jcr:title"/>
                                 </items>
                             </column>
                         </items>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/structure/header/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/structure/header/_cq_dialog/.content.xml
@@ -73,7 +73,7 @@
                                             fieldDescription="Please use the Site Title field defined above."
                                             fieldLabel="Site Title (Legacy field)"
                                             emptyText="Please use the Site Title field above."
-                                            disabled="{Boolean}true"
+                                            disabled="{Boolean}false"
                                             name="./jcr:title"/>
                                 </items>
                             </column>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/structure/header/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/structure/header/_cq_dialog/.content.xml
@@ -70,9 +70,9 @@
                                     <site-title-legacy
                                             jcr:primaryType="nt:unstructured"
                                             sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
-                                            fieldDescription="Please use the Site Title field defined above."
+                                            fieldDescription="Do not use this field. Please use the Site Title field defined above."
                                             fieldLabel="Site Title (Legacy field)"
-                                            emptyText="Please use the Site Title field above."
+                                            emptyText="Do not use this field. Please use the Site Title field above."
                                             disabled="{Boolean}false"
                                             name="./jcr:title"/>
                                 </items>


### PR DESCRIPTION
… on header component policy


## Description

Fixes issue described in #643.  New field writes to `./title` and uses the legacy `./jcr:title` as a fallback. Originally i made jcr:title a disabled field, but then if a value was written to it, there would be no way to clear it out.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
