### PR TITLE
making the rendition dispatch servlet asset type aware

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.adobe.aem.commons</groupId>
         <artifactId>assetshare</artifactId>
-        <version>2.1.11-SNAPSHOT</version>
+        <version>2.2.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.adobe.aem.commons</groupId>
         <artifactId>assetshare</artifactId>
-        <version>2.1.11-SNAPSHOT</version>
+        <version>2.2.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>assetshare.core</artifactId>

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/content/renditions/impl/AssetRenditionServlet.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/content/renditions/impl/AssetRenditionServlet.java
@@ -109,7 +109,8 @@ public class AssetRenditionServlet extends SlingSafeMethodsServlet {
                 StringUtils.isBlank(parameters.getRenditionName())) {
             return false;
         } else {
-            return assetRenditionDispatcher.getRenditionNames().contains(parameters.getRenditionName());
+            return assetRenditionDispatcher.getRenditionNames().contains(parameters.getRenditionName()) &&
+                    (assetRenditionDispatcher.getTypes().isEmpty() || assetRenditionDispatcher.getTypes().contains(parameters.getAssetType()));
         }
     }
 

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/content/renditions/package-info.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/content/renditions/package-info.java
@@ -17,7 +17,7 @@
  *
  */
 
-@Version("2.2.0")
+@Version("2.3.0")
 package com.adobe.aem.commons.assetshare.content.renditions;
 
 import org.osgi.annotation.versioning.Version;

--- a/core/src/test/java/com/adobe/aem/commons/assetshare/content/renditions/AssetRenditionParametersTest.java
+++ b/core/src/test/java/com/adobe/aem/commons/assetshare/content/renditions/AssetRenditionParametersTest.java
@@ -23,6 +23,8 @@ import com.adobe.aem.commons.assetshare.content.AssetModel;
 import com.adobe.aem.commons.assetshare.content.AssetResolver;
 import com.adobe.aem.commons.assetshare.content.impl.AssetModelImpl;
 import com.adobe.aem.commons.assetshare.content.properties.ComputedProperties;
+import com.adobe.aem.commons.assetshare.content.properties.ComputedProperty;
+import com.adobe.aem.commons.assetshare.content.properties.impl.AssetTypeImpl;
 import com.adobe.aem.commons.assetshare.content.properties.impl.ComputedPropertiesImpl;
 import com.day.cq.dam.commons.util.DamUtil;
 import io.wcm.testing.mock.aem.junit.AemContext;
@@ -54,7 +56,8 @@ public class AssetRenditionParametersTest {
         doReturn(DamUtil.resolveToAsset(ctx.resourceResolver().getResource("/content/dam/test.png"))).when(assetResolver).resolveAsset(ctx.request());
         ctx.registerService(AssetResolver.class, assetResolver);
 
-        ctx.registerService(ComputedProperties.class, new ComputedPropertiesImpl());
+        ctx.registerInjectActivateService(new AssetTypeImpl());
+        ctx.registerInjectActivateService(new ComputedPropertiesImpl());
         ctx.addModelsForClasses(AssetModelImpl.class);
 
         testAssetModel = ctx.request().adaptTo(AssetModel.class);
@@ -66,6 +69,7 @@ public class AssetRenditionParametersTest {
 
         assertEquals("t.estin.g", actual.getRenditionName());
         assertEquals("test.t.estin.g.png", actual.getFileName());
+        assertEquals("image", actual.getAssetType());
         assertFalse(actual.isDownload());
         assertTrue(actual.getParameters().isEmpty());
     }
@@ -76,6 +80,7 @@ public class AssetRenditionParametersTest {
 
         assertEquals("testing", actual.getRenditionName());
         assertEquals("test.testing.png", actual.getFileName());
+        assertEquals("image", actual.getAssetType());
         assertTrue(actual.isDownload());
         assertEquals(1, actual.getParameters().size());
         assertEquals("download", actual.getParameters().get(0));
@@ -87,6 +92,7 @@ public class AssetRenditionParametersTest {
 
         assertEquals("testing", actual.getRenditionName());
         assertEquals("test.testing.png", actual.getFileName());
+        assertEquals("image", actual.getAssetType());
         assertTrue(actual.isDownload());
         assertEquals(3, actual.getParameters().size());
         assertEquals("param1", actual.getParameters().get(0));
@@ -103,6 +109,7 @@ public class AssetRenditionParametersTest {
 
         assertEquals("testing", actual.getRenditionName());
         assertEquals("test.testing.png", actual.getFileName());
+        assertEquals("image", actual.getAssetType());
         assertTrue(actual.isDownload());
         assertEquals(3, actual.getParameters().size());
         assertEquals("download", actual.getParameters().get(0));

--- a/core/src/test/resources/com/adobe/aem/commons/assetshare/content/renditions/AssetRenditionParametersTest.json
+++ b/core/src/test/resources/com/adobe/aem/commons/assetshare/content/renditions/AssetRenditionParametersTest.json
@@ -4,7 +4,8 @@
     "jcr:content": {
       "jcr:primaryType": "nt:unstructured",
       "metadata": {
-        "jcr:primaryType": "nt:unstructured"
+        "jcr:primaryType": "nt:unstructured",
+        "dc:format": "image/png"
       },
       "renditions": {
         "jcr:primaryType": "nt:unstructured"

--- a/dispatcher/pom.xml
+++ b/dispatcher/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.adobe.aem.commons</groupId>
         <artifactId>assetshare</artifactId>
-        <version>2.1.11-SNAPSHOT</version>
+        <version>2.2.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <groupId>com.adobe.aem.commons</groupId>
     <artifactId>assetshare</artifactId>
     <packaging>pom</packaging>
-    <version>2.1.11-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
 
     <name>Asset Share Commons - Reactor Project</name>
     <description>asset-share-commons</description>

--- a/ui.apps.structure/pom.xml
+++ b/ui.apps.structure/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.adobe.aem.commons</groupId>
         <artifactId>assetshare</artifactId>
-        <version>2.1.11-SNAPSHOT</version>
+        <version>2.2.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ui.apps/pom.xml
+++ b/ui.apps/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.adobe.aem.commons</groupId>
         <artifactId>assetshare</artifactId>
-        <version>2.1.11-SNAPSHOT</version>
+        <version>2.2.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ui.content.sample/pom.xml
+++ b/ui.content.sample/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.adobe.aem.commons</groupId>
         <artifactId>assetshare</artifactId>
-        <version>2.1.11-SNAPSHOT</version>
+        <version>2.2.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ui.content/pom.xml
+++ b/ui.content/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.adobe.aem.commons</groupId>
         <artifactId>assetshare</artifactId>
-        <version>2.1.11-SNAPSHOT</version>
+        <version>2.2.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ui.frontend.theme.dark/pom.xml
+++ b/ui.frontend.theme.dark/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.adobe.aem.commons</groupId>
         <artifactId>assetshare</artifactId>
-        <version>2.1.11-SNAPSHOT</version>
+        <version>2.2.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ui.frontend.theme.light/pom.xml
+++ b/ui.frontend.theme.light/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.adobe.aem.commons</groupId>
         <artifactId>assetshare</artifactId>
-        <version>2.1.11-SNAPSHOT</version>
+        <version>2.2.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
## Description

The current rendition servlet does not respect asset type mappings in the individual dispatchers. This change adds type checking logic. 

## Related Issue

See #659 

## Motivation and Context

Especially in a DM enabled environment, you may want different rendition handlers depending on the asset type. This change allows for that to happen.

## How Has This Been Tested?

Tested locally by applying different type specific configs. Also updated unit tests to cover the changes.


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.

probably should update https://opensource.adobe.com/asset-share-commons/pages/development/asset-renditions/ to indicate that this is possible.

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
