### PR TITLE
Fix/662 - Replaced 0byte placeholder size with 100MB to prevent Oak exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- 0662 - Changed the placeholder asset size for external renditions (ie. Dynamic Media) from 0 to 100MB to prevent Oak exceptions.
+- 0662 - Commented out the Download Size column from the Downloads component until we have an API that allows up to consistently and accurately report the download zip size 
+ 
 ## [v2.1.10]
 
 ### Fixed

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/content/renditions/download/async/impl/DownloadEntryImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/content/renditions/download/async/impl/DownloadEntryImpl.java
@@ -88,8 +88,15 @@ public class DownloadEntryImpl implements DownloadEntry {
         return downloadProgress.getTotalCount();
     }
 
+    /**
+     * Note that this size is the sum of the PROVIDED sizes, and not the size of the resulting ZIP
+     * (especially in the case of external URIs downloads where the size is unknown beforehand)
+     *
+     * @return the sum of all PROVIDED (the ones you set, this is not computed by the framework) sizes of processed DownloadFiles in bytes
+     */
     @Override
     public long getTotalSize() {
+        //
         return downloadProgress.getTotalSize();
     }
 

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/content/renditions/impl/dispatchers/ExternalRedirectRenditionDispatcherImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/content/renditions/impl/dispatchers/ExternalRedirectRenditionDispatcherImpl.java
@@ -65,6 +65,8 @@ import static org.osgi.framework.Constants.SERVICE_RANKING;
 public class ExternalRedirectRenditionDispatcherImpl extends AbstractRenditionDispatcherImpl implements AssetRenditionDispatcher {
     private static Logger log = LoggerFactory.getLogger(ExternalRedirectRenditionDispatcherImpl.class);
 
+    private static Long PLACEHOLDER_SIZE_IN_BYTES = 104857600L; // 100MB
+
     private Cfg cfg;
 
     private ConcurrentHashMap<String, String> mappings;
@@ -156,7 +158,7 @@ public class ExternalRedirectRenditionDispatcherImpl extends AbstractRenditionDi
                         renditionRedirect,
                         parameters.getRenditionName());
 
-                return new AssetRendition(renditionRedirect, 0L, mimeTypeService.getMimeType(extension));
+                return new AssetRendition(renditionRedirect, PLACEHOLDER_SIZE_IN_BYTES, mimeTypeService.getMimeType(extension));
             } catch (URISyntaxException e) {
                 log.warn("Unable to create a valid URI for rendition redirect [ {} ]", renditionRedirect, e);
                 // Still sending to Async Download Framework so we can get a failure

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/content/renditions/impl/dispatchers/ExternalRedirectRenditionDispatcherImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/content/renditions/impl/dispatchers/ExternalRedirectRenditionDispatcherImpl.java
@@ -25,9 +25,6 @@ import com.adobe.aem.commons.assetshare.content.renditions.AssetRenditionDispatc
 import com.adobe.aem.commons.assetshare.content.renditions.AssetRenditionParameters;
 import com.adobe.aem.commons.assetshare.content.renditions.AssetRenditions;
 import com.adobe.aem.commons.assetshare.util.UrlUtil;
-import com.day.cq.dam.api.Asset;
-import com.day.cq.dam.api.Rendition;
-import com.day.text.Text;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/content/renditions/impl/dispatchers/InternalRedirectRenditionDispatcherImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/content/renditions/impl/dispatchers/InternalRedirectRenditionDispatcherImpl.java
@@ -142,8 +142,10 @@ public class InternalRedirectRenditionDispatcherImpl extends AbstractRenditionDi
         // If this method becomes supportable by the AEM Async Asset Download framework, review the code at:
         // https://gist.github.com/davidjgonzalez/66e481b54aafb1b900a579ee95848d8f
         // As this might prove useful in it's implementation.
-        throw new UnsupportedOperationException(String.format("[ %s ] is not supported by the AEM Async Asset Download Framework.",
-                this.getClass().getName()));
+
+        log.warn("[ {} ] is not supported by the AEM Async Asset Download Framework.", this.getClass().getName());
+
+        return null;
     }
 
     @Override

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/downloads/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/downloads/_cq_dialog/.content.xml
@@ -48,13 +48,15 @@
                                             name="./numberOfFilesColumnTitle"
                                             required="{Boolean}true"/>
 
+                                    <!-- Hiding until the Download size can be accurately computed -->
                                     <column-download-size-title
                                             jcr:primaryType="nt:unstructured"
                                             sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                             emptyText="Download size"
                                             fieldLabel="Download Size Column Title"
                                             name="./downloadSizeTitle"
-                                            required="{Boolean}true"/>
+                                            renderHidden="{Boolean}true"
+                                            required="{Boolean}false"/>
 
                                     <failed-download-file-name
                                             jcr:primaryType="nt:unstructured"

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/downloads/downloads.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/downloads/downloads.html
@@ -66,7 +66,9 @@
                             <th class="cmp-modal-downloads__col--archive-name"></th>
                             <th class="cmp-modal-downloads__col--file-status">${ properties.statusColumnTitle || 'Status' @ i18n }</th>
                             <th class="cmp-modal-downloads__col--total-count">${ properties.numberOfFilesColumnTitle || 'No. of files' @ i18n }</th>
+                            <!--/*
                             <th class="cmp-modal-downloads__col--file-size">${ properties.downloadSizeTitle || 'Download size' @ i18n }</th>
+                            */-->
                             <th class="cmp-modal-downloads__col--file-action"></th>
                             <th class="cmp-modal-downloads__col--file-action"></th>
                         </tr>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/downloads/templates/download.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/downloads/templates/download.html
@@ -59,10 +59,15 @@ Represents a logical download from Asset Share Commons.
             <td class="cmp-modal-downloads__col--total-count accordion-trigger">
                 ${download.archive ? download.successCount : '1'}
             </td>
-            <!--/* File size */-->
+
+            <!--/* File size
+                   Hiding file size as this is not necessarily accurate and can be very confusing when it's not.
+                   This is especially the case for external URIs whose sizes are not known BEFORE they are retrieved.
             <td class="cmp-modal-downloads__col--file-size accordion-trigger">
                 ${download.formattedTotalSize || 0}
             </td>
+            */-->
+
             <!--/* Progress/Download */-->
             <td class="cmp-modal-downloads__col--action"
                 data-asset-share-id="download-archive"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

See #662 

* Replaced ExternalRedirectRenditionDispatcherImpl's setting of 0 byte rendition size with 100MB as Oak no longer supports 0 bytes (and will fail the entire download/throw exception)
* Commented Download Size column from Downloads components as we cannot actually accurately/consistently compute the zip size using available APIs.
   * Commented out so hopefully when the AEM API provides the actual zip size, we can uncomment or revert as needed. 

## How Has This Been Tested?

Tested on AEM CS using static and dynamic media renditions.

## Screenshots (if appropriate):

![2021-09-21 at 5 41 PM](https://user-images.githubusercontent.com/1451868/134251673-003a0910-e70d-4e08-909f-b4778e934397.jpg)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
