### PR TITLE
[674] - remove ComponentExporter resolves #674

### DIFF
--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/cart/impl/CartImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/cart/impl/CartImpl.java
@@ -38,7 +38,7 @@ import java.util.Collection;
 
 @Model(
         adaptables = {SlingHttpServletRequest.class},
-        adapters = {Cart.class, ComponentExporter.class},
+        adapters = Cart.class,
         resourceType = {CartImpl.RESOURCE_TYPE}
 )
 @Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME, extensions = ExporterConstants.SLING_MODEL_EXTENSION)

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/download/impl/DownloadImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/download/impl/DownloadImpl.java
@@ -51,7 +51,7 @@ import static javax.jcr.query.Query.JCR_SQL2;
 
 @Model(
         adaptables = {SlingHttpServletRequest.class},
-        adapters = {Download.class, ComponentExporter.class},
+        adapters = Download.class,
         resourceType = {DownloadImpl.RESOURCE_TYPE},
         defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL
 )

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/share/impl/EmailShareImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/share/impl/EmailShareImpl.java
@@ -39,7 +39,7 @@ import java.util.Map;
 
 @Model(
         adaptables = {SlingHttpServletRequest.class},
-        adapters = {EmailShare.class, ComponentExporter.class},
+        adapters = EmailShare.class,
         resourceType = {EmailShareImpl.RESOURCE_TYPE},
         defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL
 )

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/impl/ActionButtonsImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/impl/ActionButtonsImpl.java
@@ -36,7 +36,7 @@ import javax.annotation.Nonnull;
 
 @Model(
         adaptables = {SlingHttpServletRequest.class},
-        adapters = {ActionButtons.class, ComponentExporter.class},
+        adapters = ActionButtons.class,
         resourceType = ActionButtonsImpl.RESOURCE_TYPE,
         defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL
 )

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/impl/EditorLinksImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/impl/EditorLinksImpl.java
@@ -39,7 +39,7 @@ import javax.annotation.Nonnull;
 
 @Model(
         adaptables = {SlingHttpServletRequest.class},
-        adapters = {EditorLinks.class, ComponentExporter.class},
+        adapters = EditorLinks.class,
         resourceType = {EditorLinksImpl.RESOURCE_TYPE},
         defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL
 )

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/impl/ImageImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/impl/ImageImpl.java
@@ -47,7 +47,7 @@ import java.util.regex.Pattern;
 
 @Model(
         adaptables = {SlingHttpServletRequest.class},
-        adapters = {Image.class, ComponentExporter.class},
+        adapters = Image.class,
         resourceType = {ImageImpl.RESOURCE_TYPE},
         defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL
 )

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/impl/MetadataImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/impl/MetadataImpl.java
@@ -47,7 +47,7 @@ import java.util.Locale;
 
 @Model(
         adaptables = SlingHttpServletRequest.class,
-        adapters = {Metadata.class, ComponentExporter.class},
+        adapters = Metadata.class,
         resourceType = {MetadataImpl.RESOURCE_TYPE},
         defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL
 )

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/impl/RenditionsImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/impl/RenditionsImpl.java
@@ -58,7 +58,7 @@ import java.util.regex.Pattern;
 
 @Model(
         adaptables = {SlingHttpServletRequest.class},
-        adapters = {Renditions.class, ComponentExporter.class},
+        adapters = Renditions.class,
         resourceType = {RenditionsImpl.RESOURCE_TYPE}
 )
 @Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME, extensions = ExporterConstants.SLING_MODEL_EXTENSION)

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/impl/TagsImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/impl/TagsImpl.java
@@ -45,7 +45,7 @@ import java.util.*;
 
 @Model(
         adaptables = {SlingHttpServletRequest.class},
-        adapters = {Tags.class, ComponentExporter.class},
+        adapters = Tags.class,
         resourceType = {TagsImpl.RESOURCE_TYPE},
         defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL
 )

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/impl/TitleImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/impl/TitleImpl.java
@@ -37,7 +37,7 @@ import javax.annotation.PostConstruct;
 
 @Model(
         adaptables = {SlingHttpServletRequest.class},
-        adapters = {Title.class, ComponentExporter.class},
+        adapters = Title.class,
         resourceType = {TitleImpl.RESOURCE_TYPE},
         defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL
 )

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/impl/VideoImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/impl/VideoImpl.java
@@ -27,7 +27,7 @@ import java.util.regex.Pattern;
  */
 @Model(
         adaptables = {SlingHttpServletRequest.class},
-        adapters = {Video.class, ComponentExporter.class},
+        adapters = Video.class,
         resourceType = {VideoImpl.RESOURCE_TYPE},
         defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL)
 @Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME, extensions = ExporterConstants.SLING_MODEL_EXTENSION)

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/DatePredicateImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/DatePredicateImpl.java
@@ -47,7 +47,7 @@ import java.util.List;
 
 @Model(
         adaptables = {SlingHttpServletRequest.class},
-        adapters = {DatePredicate.class, ComponentExporter.class},
+        adapters = DatePredicate.class,
         resourceType = {DatePredicateImpl.RESOURCE_TYPE},
         defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL
 )

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/FreeformTextPredicatePredicateImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/FreeformTextPredicatePredicateImpl.java
@@ -45,7 +45,7 @@ import static java.util.Collections.EMPTY_LIST;
 
 @Model(
         adaptables = {SlingHttpServletRequest.class},
-        adapters = {FreeformTextPredicate.class, ComponentExporter.class},
+        adapters = FreeformTextPredicate.class,
         resourceType = {FreeformTextPredicatePredicateImpl.RESOURCE_TYPE},
         defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL
 )

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/FulltextPredicateImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/FulltextPredicateImpl.java
@@ -40,7 +40,7 @@ import java.util.HashMap;
 
 @Model(
         adaptables = {SlingHttpServletRequest.class},
-        adapters = {FulltextPredicate.class, ComponentExporter.class},
+        adapters = FulltextPredicate.class,
         resourceType = {FulltextPredicateImpl.RESOURCE_TYPE}
 )
 @Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME, extensions = ExporterConstants.SLING_MODEL_EXTENSION)

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/HiddenPredicateImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/HiddenPredicateImpl.java
@@ -45,7 +45,7 @@ import java.util.*;
 
 @Model(
         adaptables = {SlingHttpServletRequest.class},
-        adapters = {HiddenPredicate.class, ComponentExporter.class},
+        adapters = HiddenPredicate.class,
         resourceType = {HiddenPredicateImpl.RESOURCE_TYPE}
 )
 @Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME, extensions = ExporterConstants.SLING_MODEL_EXTENSION)

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/PagePredicateImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/PagePredicateImpl.java
@@ -60,7 +60,7 @@ import java.util.Map;
 
 @Model(
         adaptables = {SlingHttpServletRequest.class},
-        adapters = {PagePredicate.class, ComponentExporter.class},
+        adapters = PagePredicate.class,
         resourceType = {PagePredicateImpl.RESOURCE_TYPE},
         defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL
 )

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/PathPredicateImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/PathPredicateImpl.java
@@ -51,7 +51,7 @@ import java.util.Map;
 
 @Model(
         adaptables = {SlingHttpServletRequest.class},
-        adapters = {PathPredicate.class, ComponentExporter.class},
+        adapters = PathPredicate.class,
         resourceType = {PathPredicateImpl.RESOURCE_TYPE},
         defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL
 )

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/PropertyPredicateImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/PropertyPredicateImpl.java
@@ -49,7 +49,7 @@ import java.util.Map;
 
 @Model(
         adaptables = {SlingHttpServletRequest.class},
-        adapters = {PropertyPredicate.class, ComponentExporter.class},
+        adapters = PropertyPredicate.class,
         resourceType = {PropertyPredicateImpl.RESOURCE_TYPE},
         defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL
 )

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/SortPredicateImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/SortPredicateImpl.java
@@ -49,7 +49,7 @@ import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
 
 @Model(
         adaptables = {SlingHttpServletRequest.class},
-        adapters = {SortPredicate.class, ComponentExporter.class},
+        adapters = SortPredicate.class,
         resourceType = {SortPredicateImpl.RESOURCE_TYPE}
 )
 @Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME, extensions = ExporterConstants.SLING_MODEL_EXTENSION)

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/TagsPredicateImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/TagsPredicateImpl.java
@@ -50,7 +50,7 @@ import java.util.Locale;
 
 @Model(
         adaptables = {SlingHttpServletRequest.class},
-        adapters = {TagsPredicate.class, ComponentExporter.class},
+        adapters = TagsPredicate.class,
         resourceType = {TagsPredicateImpl.RESOURCE_TYPE},
         defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL
 )

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/search/impl/SearchConfigImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/search/impl/SearchConfigImpl.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
 
 @Model(
         adaptables = {SlingHttpServletRequest.class},
-        adapters = {SearchConfig.class, ComponentExporter.class},
+        adapters = SearchConfig.class,
         resourceType = {SearchConfigImpl.RESOURCE_TYPE}
 )
 @Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME, extensions = ExporterConstants.SLING_MODEL_EXTENSION)

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/search/impl/StatisticsImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/search/impl/StatisticsImpl.java
@@ -16,7 +16,7 @@ import javax.annotation.PostConstruct;
 
 @Model(
         adaptables = {SlingHttpServletRequest.class},
-        adapters = {Statistics.class, ComponentExporter.class},
+        adapters = Statistics.class,
         resourceType = {StatisticsImpl.RESOURCE_TYPE},
         defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL
 )

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/structure/impl/HeaderImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/structure/impl/HeaderImpl.java
@@ -43,7 +43,7 @@ import java.util.List;
 
 @Model(
         adaptables = {SlingHttpServletRequest.class},
-        adapters = {Header.class, ComponentExporter.class},
+        adapters = Header.class,
         resourceType = {HeaderImpl.RESOURCE_TYPE}
 )
 @Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME, extensions = ExporterConstants.SLING_MODEL_EXTENSION)

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/structure/impl/UserMenuImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/structure/impl/UserMenuImpl.java
@@ -43,7 +43,7 @@ import javax.jcr.RepositoryException;
 
 @Model(
         adaptables = {SlingHttpServletRequest.class},
-        adapters = {UserMenu.class, ComponentExporter.class},
+        adapters = UserMenu.class,
         resourceType = UserMenuImpl.RESOURCE_TYPE
 )
 @Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME, extensions = ExporterConstants.SLING_MODEL_EXTENSION)


### PR DESCRIPTION
resolved #674 

In case when ComponentExporter is present in adapter section, Default JSON exporter is overridden for components that don't have custom exporter. This is causing issues with SPA framework

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
