### PR TITLE
#690 Added missing default labels with @ i18N

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/action-buttons/action-buttons.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/action-buttons/action-buttons.html
@@ -24,33 +24,33 @@
      data-sly-test.ready="${actionButtons.ready}">
 
     <div class="ui basic segment">
-        <h4 class="ui header" data-sly-test="${!properties['hideLabel']}">${properties['label']}</h4>
+        <h4 class="ui header" data-sly-test="${!properties['hideLabel']}">${properties['label'] || 'Actions' @ i18n}</h4>
 		<div class="actions cmp-action-buttons">
             <button class="ui primary button cmp-action-buttons__button"
                     data-asset-share-id="download-asset"
                     data-asset-share-asset="${asset.path}"
                     data-asset-share-license="${config.licenseEnabled ? asset.properties['license'] : ''}"
                     data-sly-test="${properties['downloadLabel'] && config.downloadEnabled}">
-                ${properties['downloadLabel']}
+                ${properties['downloadLabel'] || 'Download' @ i18n}
             </button>
             <button class="ui button cmp-action-buttons__button"
                     data-asset-share-id="share-asset"
                     data-asset-share-asset="${asset.path}"
                     data-sly-test="${properties['shareLabel'] && config.shareEnabled}">
-                ${properties['shareLabel']}
+                ${properties['shareLabel'] || 'Share' @ i18n}
             </button>
             <button class="ui button cmp-action-buttons__button"
                     data-asset-share-id="add-to-cart"
                     data-asset-share-asset="${asset.path}"
                     data-asset-share-license="${config.licenseEnabled ? asset.properties['license'] : ''}"
                     data-sly-test.cartEnabled="${properties['addToCartLabel'] && properties['removeFromCartLabel'] && config.cartEnabled}">
-                ${properties['addToCartLabel']}
+                ${properties['addToCartLabel'] || 'Add to Cart' @ i18n}
             </button>
             <button class="ui button cmp-action-buttons__button hidden"
                     data-asset-share-id="remove-from-cart"
                     data-asset-share-asset="${asset.path}"
                     data-sly-test="${cartEnabled}">
-               ${properties['removeFromCartLabel']}
+               ${properties['removeFromCartLabel'] || 'Remove from Cart' @ i18n}
             </button>
         </div>	
     </div>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/action-buttons/action-buttons.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/action-buttons/action-buttons.html
@@ -24,33 +24,33 @@
      data-sly-test.ready="${actionButtons.ready}">
 
     <div class="ui basic segment">
-        <h4 class="ui header" data-sly-test="${!properties['hideLabel']}">${properties['label'] || 'Actions' @ i18n}</h4>
+        <h4 class="ui header" data-sly-test="${!properties['hideLabel']}">${properties['label'] @ i18n}</h4>
 		<div class="actions cmp-action-buttons">
             <button class="ui primary button cmp-action-buttons__button"
                     data-asset-share-id="download-asset"
                     data-asset-share-asset="${asset.path}"
                     data-asset-share-license="${config.licenseEnabled ? asset.properties['license'] : ''}"
                     data-sly-test="${properties['downloadLabel'] && config.downloadEnabled}">
-                ${properties['downloadLabel'] || 'Download' @ i18n}
+                ${properties['downloadLabel'] @ i18n}
             </button>
             <button class="ui button cmp-action-buttons__button"
                     data-asset-share-id="share-asset"
                     data-asset-share-asset="${asset.path}"
                     data-sly-test="${properties['shareLabel'] && config.shareEnabled}">
-                ${properties['shareLabel'] || 'Share' @ i18n}
+                ${properties['shareLabel'] @ i18n}
             </button>
             <button class="ui button cmp-action-buttons__button"
                     data-asset-share-id="add-to-cart"
                     data-asset-share-asset="${asset.path}"
                     data-asset-share-license="${config.licenseEnabled ? asset.properties['license'] : ''}"
                     data-sly-test.cartEnabled="${properties['addToCartLabel'] && properties['removeFromCartLabel'] && config.cartEnabled}">
-                ${properties['addToCartLabel'] || 'Add to Cart' @ i18n}
+                ${properties['addToCartLabel'] @ i18n}
             </button>
             <button class="ui button cmp-action-buttons__button hidden"
                     data-asset-share-id="remove-from-cart"
                     data-asset-share-asset="${asset.path}"
                     data-sly-test="${cartEnabled}">
-               ${properties['removeFromCartLabel'] || 'Remove from Cart' @ i18n}
+               ${properties['removeFromCartLabel'] @ i18n}
             </button>
         </div>	
     </div>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/editor-links/editor-links.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/editor-links/editor-links.html
@@ -23,14 +23,14 @@
      data-sly-test.ready="${editorLinks.ready}">
 
     <h4 class="ui header"
-        data-sly-test="${!properties['hideLabel']}">${properties['label'] || 'AEM Editor Links' @ i18n}</h4>
+        data-sly-test="${!properties['hideLabel']}">${properties['label'] @ i18n}</h4>
 
     <ul>
         <li data-sly-test.assetDetailsLinkLabel="${properties['assetDetailsLinkLabel']}">
-            <a href="${editorLinks.assetDetailsEditorPath}" target="_blank">${assetDetailsLinkLabel || 'Open asset in AEM Assets Editor' @ i18n}</a>
+            <a href="${editorLinks.assetDetailsEditorPath}" target="_blank">${assetDetailsLinkLabel @ i18n}</a>
         </li>
         <li data-sly-test.assetFolderLinkLabel="${properties['assetFolderLinkLabel']}">
-            <a href="${editorLinks.assetFolderEditorPath}" target="_blank">${assetFolderLinkLabel || 'Open asset\'s folder in AEM Assets Editor' @ i18n}</a>
+            <a href="${editorLinks.assetFolderEditorPath}" target="_blank">${assetFolderLinkLabel @ i18n}</a>
         </li>
     </ul>
 

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/editor-links/editor-links.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/editor-links/editor-links.html
@@ -23,14 +23,14 @@
      data-sly-test.ready="${editorLinks.ready}">
 
     <h4 class="ui header"
-        data-sly-test="${!properties['hideLabel']}">${properties['label']}</h4>
+        data-sly-test="${!properties['hideLabel']}">${properties['label'] || 'AEM Editor Links' @ i18n}</h4>
 
     <ul>
         <li data-sly-test.assetDetailsLinkLabel="${properties['assetDetailsLinkLabel']}">
-            <a href="${editorLinks.assetDetailsEditorPath}" target="_blank">${assetDetailsLinkLabel}</a>
+            <a href="${editorLinks.assetDetailsEditorPath}" target="_blank">${assetDetailsLinkLabel || 'Open asset in AEM Assets Editor' @ i18n}</a>
         </li>
         <li data-sly-test.assetFolderLinkLabel="${properties['assetFolderLinkLabel']}">
-            <a href="${editorLinks.assetFolderEditorPath}" target="_blank">${assetFolderLinkLabel}</a>
+            <a href="${editorLinks.assetFolderEditorPath}" target="_blank">${assetFolderLinkLabel || 'Open asset\'s folder in AEM Assets Editor' @ i18n}</a>
         </li>
     </ul>
 

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/metadata/metadata.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/metadata/metadata.html
@@ -25,10 +25,10 @@
 
     <div class="ui basic segment">
         <h4 class="ui header"
-            data-sly-test="${!properties['hideLabel']}">${properties['label']}</h4>
+            data-sly-test="${!properties['hideLabel']}">${properties['label'] @ i18n}</h4>
 
         <sly data-sly-test.emptyValue="${field.empty}">
-            <p>${properties['emptyText']}</p>
+            <p>${properties['emptyText'] @ i18n}</p>
         </sly>
 
         <sly data-sly-test.emptyValue="${!field.empty}">

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/renditions/renditions.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/renditions/renditions.html
@@ -24,7 +24,7 @@
      data-sly-test.ready="${renditions.ready}">
 
     <div class="ui basic segment">
-        <h4 class="ui header" data-sly-test="${!properties['hideLabel']}">${properties['label']}</h4>
+        <h4 class="ui header" data-sly-test="${!properties['hideLabel']}">${properties['label'] || 'Renditions' @ i18n}</h4>
 
         <div class="ui labels"
              data-sly-list.rendition="${renditions.renditions}">

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/renditions/renditions.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/renditions/renditions.html
@@ -24,7 +24,7 @@
      data-sly-test.ready="${renditions.ready}">
 
     <div class="ui basic segment">
-        <h4 class="ui header" data-sly-test="${!properties['hideLabel']}">${properties['label'] || 'Renditions' @ i18n}</h4>
+        <h4 class="ui header" data-sly-test="${!properties['hideLabel']}">${properties['label'] @ i18n}</h4>
 
         <div class="ui labels"
              data-sly-list.rendition="${renditions.renditions}">

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/tags/tags.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/tags/tags.html
@@ -23,9 +23,9 @@
      data-sly-test.ready="${field.ready}">
 
     <div class="ui basic segment">
-        <h4 class="ui header" data-sly-test="${!properties['hideLabel']}">${properties['label']}</h4>
+        <h4 class="ui header" data-sly-test="${!properties['hideLabel']}">${properties['label'] || 'Tags' @ i18n}</h4>
 
-        <p data-sly-test.empty="${field.tagTitles.size == 0}">${properties['emptyText']}</p>
+        <p data-sly-test.empty="${field.tagTitles.size == 0}">${properties['emptyText'] @ i18n}</p>
 
         <div class="ui labels"
              data-sly-list.tagTitle="${field.tagTitles}">

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/tags/tags.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/tags/tags.html
@@ -23,7 +23,7 @@
      data-sly-test.ready="${field.ready}">
 
     <div class="ui basic segment">
-        <h4 class="ui header" data-sly-test="${!properties['hideLabel']}">${properties['label'] || 'Tags' @ i18n}</h4>
+        <h4 class="ui header" data-sly-test="${!properties['hideLabel']}">${properties['label'] @ i18n}</h4>
 
         <p data-sly-test.empty="${field.tagTitles.size == 0}">${properties['emptyText'] @ i18n}</p>
 

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/video/video.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/video/video.html
@@ -23,7 +23,7 @@
 
 <h4 class="ui header center aligned" 
     data-sly-test="${!video.isVideoAsset}"> 
-	${properties['invalidFormatMsg']}
+	${properties['invalidFormatMsg'] @ i18n}
 </h4>
 	<sly data-sly-test="${video.isVideoAsset}">
 		<sly data-sly-test="${properties.computedProperty =='thumbnail'}">

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/cart/cart.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/cart/cart.html
@@ -42,7 +42,7 @@
     <i class="close icon"></i>
 
     <div class="header">
-        ${properties['modalTitle'] || 'Cart' @ i18n}
+        ${properties['modalTitle'] @ i18n}
     </div>
     <div class="scrolling content"
          data-asset-share-id="cart-items">
@@ -78,30 +78,30 @@
 
         <p class="cmp-modal-cart__empty-text"
            data-sly-test="${cart.assets.size == 0}">
-            ${properties['emptyText'] || 'Your cart is empty' @ i18n}
+            ${properties['emptyText'] @ i18n}
         </p>
 
     </div>
     <div class="actions">
         <div class="ui black deny button">
-            ${properties['closeButton'] || 'Close' @ i18n}
+            ${properties['closeButton'] @ i18n}
         </div>
         <div class="ui black button align left"
              data-sly-test="${cart.assets.size > 0}"
              data-asset-share-id="clear-cart">
-            ${properties['clearButton'] || 'Clear Cart' @ i18n}
+            ${properties['clearButton'] @ i18n}
         </div>
         <div class="ui primary right labeled icon button"
         	 data-asset-share-id="share-all"
              data-sly-test="${config.shareEnabledCart && cart.assets.size > 0}">
-            ${properties['shareButton'] || 'Share Cart' @ i18n}
+            ${properties['shareButton'] @ i18n}
              <i class="send icon"></i>
         </div>
         <button data-sly-test="${config.downloadEnabledCart && cart.assets.size > 0}"
         	    data-asset-share-id="download-all"
                 type="submit"
                 class="ui postive primary right labeled icon button">
-            ${properties['downloadButton'] || 'Download Cart' @ i18n}
+            ${properties['downloadButton'] @ i18n}
             <i class="download icon"></i>
         </button>
     </div>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/cart/cart.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/cart/cart.html
@@ -42,7 +42,7 @@
     <i class="close icon"></i>
 
     <div class="header">
-        ${properties['modalTitle']}
+        ${properties['modalTitle'] || 'Cart' @ i18n}
     </div>
     <div class="scrolling content"
          data-asset-share-id="cart-items">
@@ -78,30 +78,30 @@
 
         <p class="cmp-modal-cart__empty-text"
            data-sly-test="${cart.assets.size == 0}">
-            ${properties['emptyText']}
+            ${properties['emptyText'] || 'Your cart is empty' @ i18n}
         </p>
 
     </div>
     <div class="actions">
         <div class="ui black deny button">
-            ${properties['closeButton']}
+            ${properties['closeButton'] || 'Close' @ i18n}
         </div>
         <div class="ui black button align left"
              data-sly-test="${cart.assets.size > 0}"
              data-asset-share-id="clear-cart">
-            ${properties['clearButton']}
+            ${properties['clearButton'] || 'Clear Cart' @ i18n}
         </div>
         <div class="ui primary right labeled icon button"
         	 data-asset-share-id="share-all"
              data-sly-test="${config.shareEnabledCart && cart.assets.size > 0}">
-            ${properties['shareButton']}
+            ${properties['shareButton'] || 'Share Cart' @ i18n}
              <i class="send icon"></i>
         </div>
         <button data-sly-test="${config.downloadEnabledCart && cart.assets.size > 0}"
         	    data-asset-share-id="download-all"
                 type="submit"
                 class="ui postive primary right labeled icon button">
-            ${properties['downloadButton']}
+            ${properties['downloadButton'] || 'Download Cart' @ i18n}
             <i class="download icon"></i>
         </button>
     </div>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/download/download.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/download/download.html
@@ -45,12 +45,12 @@
         <div class="header">${"Direct Downloads enabled" @ i18n}</div>
     </div>
     <div class="header">
-        ${properties['modalTitle'] || 'Download' @ i18n}
+        ${properties['modalTitle'] @ i18n}
     </div>
 
     <div class="image scrolling content cmp-content">
         <div class="ui medium image">
-            <h3 class="ui header">${properties['assetListTitle'] || 'Assets' @ i18n}</h3>
+            <h3 class="ui header">${properties['assetListTitle'] @ i18n}</h3>
 
             <div class="ui list" data-sly-list.asset="${download.assets}">
                 <div class="item">
@@ -63,7 +63,7 @@
         </div>
 
         <div class="description ui form">
-            <h3 class="ui header">${properties['downloadOptionsTitle'] || 'Download options' @ i18n}</h3>
+            <h3 class="ui header">${properties['downloadOptionsTitle'] @ i18n}</h3>
 
             <sly data-sly-list.asset="${download.assets}">
                 <input type="hidden" name="path"  value="${asset.url}"/>
@@ -78,7 +78,7 @@
                 <sly data-sly-test="${properties.selectAllLabel && assetRenditionsGroup.items.size > 1}">
                     <div class="ui checkbox cmp-modal-download__asset-rendition-group-option">
                         <input type="checkbox" onchange="$(this).closest('.cmp-modal-download__asset-rendition-group').find('input[type=\'checkbox\']').prop('checked', $(this).prop('checked'));">
-                        <label>${properties.selectAllLabel || 'Select all' @ i18n}</label>
+                        <label>${properties.selectAllLabel @ i18n}</label>
                     </div>
                     <br/>
                 </sly>
@@ -97,10 +97,10 @@
 
     <div class="actions cmp-footer__actions">
         <div class="ui deny button">
-            ${properties['cancelButton'] || 'Cancel' @ i18n}
+            ${properties['cancelButton'] @ i18n}
         </div>
         <button type="submit" class="ui positive primary right labeled icon button ${isMaxSize ? 'disabled': ''}">
-            ${properties['downloadButton'] || 'Download' @ i18n}
+            ${properties['downloadButton'] @ i18n}
             <i class="download icon"></i>
         </button>
     </div>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/download/download.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/download/download.html
@@ -45,12 +45,12 @@
         <div class="header">${"Direct Downloads enabled" @ i18n}</div>
     </div>
     <div class="header">
-        ${properties['modalTitle']}
+        ${properties['modalTitle'] || 'Download' @ i18n}
     </div>
 
     <div class="image scrolling content cmp-content">
         <div class="ui medium image">
-            <h3 class="ui header">${properties['assetListTitle']}</h3>
+            <h3 class="ui header">${properties['assetListTitle'] || 'Assets' @ i18n}</h3>
 
             <div class="ui list" data-sly-list.asset="${download.assets}">
                 <div class="item">
@@ -63,7 +63,7 @@
         </div>
 
         <div class="description ui form">
-            <h3 class="ui header">${properties['downloadOptionsTitle']}</h3>
+            <h3 class="ui header">${properties['downloadOptionsTitle'] || 'Download options' @ i18n}</h3>
 
             <sly data-sly-list.asset="${download.assets}">
                 <input type="hidden" name="path"  value="${asset.url}"/>
@@ -78,7 +78,7 @@
                 <sly data-sly-test="${properties.selectAllLabel && assetRenditionsGroup.items.size > 1}">
                     <div class="ui checkbox cmp-modal-download__asset-rendition-group-option">
                         <input type="checkbox" onchange="$(this).closest('.cmp-modal-download__asset-rendition-group').find('input[type=\'checkbox\']').prop('checked', $(this).prop('checked'));">
-                        <label>${properties.selectAllLabel}</label>
+                        <label>${properties.selectAllLabel || 'Select all' @ i18n}</label>
                     </div>
                     <br/>
                 </sly>
@@ -97,10 +97,10 @@
 
     <div class="actions cmp-footer__actions">
         <div class="ui deny button">
-            ${properties['cancelButton']}
+            ${properties['cancelButton'] || 'Cancel' @ i18n}
         </div>
         <button type="submit" class="ui positive primary right labeled icon button ${isMaxSize ? 'disabled': ''}">
-            ${properties['downloadButton']}
+            ${properties['downloadButton'] || 'Download' @ i18n}
             <i class="download icon"></i>
         </button>
     </div>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/download/templates/legacy.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/download/templates/legacy.html
@@ -37,17 +37,17 @@
 
         <div data-sly-test.isMaxSize="${download.maxContentSize > 0 && download.maxContentSize < download.downloadContentSize}"
              class="ui attached warning message cmp-message">
-            ${properties['maxContentSizeMessage'] || 'Maximum content size of download exceeded.' @ i18n}
+            ${properties['maxContentSizeMessage'] @ i18n}
             <br/>
             <label>${"Limit" @ i18n}:</label> <span class="detail">${download.maxContentSizeLabel}</span> |
             <label>${"Current Size" @ i18n}:</label> <span class="detail">${download.downloadContentSizeLabel}</span>
         </div>
         <div class="header">
-            ${properties['modalTitle'] || 'Download' @ i18n}
+            ${properties['modalTitle'] @ i18n}
         </div>
         <div class="image scrolling content cmp-content">
             <div class="ui medium image">
-                <div class="ui header">${properties['assetListTitle'] || 'Assets' @ i18n}</div>
+                <div class="ui header">${properties['assetListTitle'] @ i18n}</div>
 
                 <div class="ui list" data-sly-list.asset="${download.assets}">
                     <div class="item">
@@ -60,7 +60,7 @@
 
             </div>
             <div class="description ui form">
-                <div class="ui header">${properties['downloadOptionsTitle'] ||'Download options' @ i18n}</div>
+                <div class="ui header">${properties['downloadOptionsTitle'] @ i18n}</div>
 
                 <sly data-sly-list.asset="${download.assets}">
                     <input type="hidden" name="path"  value="${asset.url}"/>
@@ -86,10 +86,10 @@
         </div>
         <div class="actions cmp-footer__actions">
             <div class="ui deny button">
-                ${properties['cancelButton'] || 'Cancel' @ i18n}
+                ${properties['cancelButton'] @ i18n}
             </div>
             <button type="submit" class="ui positive primary right labeled icon button ${isMaxSize ? 'disabled': ''}">
-                ${properties['downloadButton'] || 'Download' @ i18n}
+                ${properties['downloadButton'] @ i18n}
                 <i class="download icon"></i>
             </button>
         </div>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/download/templates/legacy.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/download/templates/legacy.html
@@ -37,17 +37,17 @@
 
         <div data-sly-test.isMaxSize="${download.maxContentSize > 0 && download.maxContentSize < download.downloadContentSize}"
              class="ui attached warning message cmp-message">
-            ${properties['maxContentSizeMessage']}
+            ${properties['maxContentSizeMessage'] || 'Maximum content size of download exceeded.' @ i18n}
             <br/>
             <label>${"Limit" @ i18n}:</label> <span class="detail">${download.maxContentSizeLabel}</span> |
             <label>${"Current Size" @ i18n}:</label> <span class="detail">${download.downloadContentSizeLabel}</span>
         </div>
         <div class="header">
-            ${properties['modalTitle']}
+            ${properties['modalTitle'] || 'Download' @ i18n}
         </div>
         <div class="image scrolling content cmp-content">
             <div class="ui medium image">
-                <div class="ui header">${properties['assetListTitle']}</div>
+                <div class="ui header">${properties['assetListTitle'] || 'Assets' @ i18n}</div>
 
                 <div class="ui list" data-sly-list.asset="${download.assets}">
                     <div class="item">
@@ -60,7 +60,7 @@
 
             </div>
             <div class="description ui form">
-                <div class="ui header">${properties['downloadOptionsTitle']}</div>
+                <div class="ui header">${properties['downloadOptionsTitle'] ||'Download options' @ i18n}</div>
 
                 <sly data-sly-list.asset="${download.assets}">
                     <input type="hidden" name="path"  value="${asset.url}"/>
@@ -86,10 +86,10 @@
         </div>
         <div class="actions cmp-footer__actions">
             <div class="ui deny button">
-                ${properties['cancelButton']}
+                ${properties['cancelButton'] || 'Cancel' @ i18n}
             </div>
             <button type="submit" class="ui positive primary right labeled icon button ${isMaxSize ? 'disabled': ''}">
-                ${properties['downloadButton']}
+                ${properties['downloadButton'] || 'Download' @ i18n}
                 <i class="download icon"></i>
             </button>
         </div>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/license/license.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/license/license.html
@@ -32,7 +32,7 @@
      class="ui long modal cmp-modal-license--wrapper cmp-modal">
     <i class="close icon"></i>
     <div class="header">
-        ${properties['modalTitle']}
+        ${properties['modalTitle'] || 'License Agreement' @ i18n}
     </div>
     <div class="cmp-content image scrolling content">
         <div class="ui medium image">
@@ -48,11 +48,11 @@
 
     <div class="actions">
         <div class="ui deny button">
-            ${properties['rejectButtonText']}
+            ${properties['rejectButtonText'] || 'Reject' @ i18n}
         </div>
         <div class="ui positive right labeled icon button"
              data-asset-share-id="license-accept">
-            ${properties['acceptButtonText']}
+            ${properties['acceptButtonText'] || 'Accept Terms' @ i18n}
             <i class="checkmark icon"></i>
         </div>
     </div>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/license/license.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/license/license.html
@@ -32,7 +32,7 @@
      class="ui long modal cmp-modal-license--wrapper cmp-modal">
     <i class="close icon"></i>
     <div class="header">
-        ${properties['modalTitle'] || 'License Agreement' @ i18n}
+        ${properties['modalTitle'] @ i18n}
     </div>
     <div class="cmp-content image scrolling content">
         <div class="ui medium image">
@@ -48,11 +48,11 @@
 
     <div class="actions">
         <div class="ui deny button">
-            ${properties['rejectButtonText'] || 'Reject' @ i18n}
+            ${properties['rejectButtonText'] @ i18n}
         </div>
         <div class="ui positive right labeled icon button"
              data-asset-share-id="license-accept">
-            ${properties['acceptButtonText'] || 'Accept Terms' @ i18n}
+            ${properties['acceptButtonText'] @ i18n}
             <i class="checkmark icon"></i>
         </div>
     </div>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/share/share.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/share/share.html
@@ -36,12 +36,12 @@
 	<i class="close icon"></i>
 
 	<div class="header">
-		${properties['modalTitle']}
+		${properties['modalTitle'] || 'Share' @ i18n}
 	</div>
 
 	<!--/* Loading */-->
 	<div class="cmp-content--loading ui inverted dimmer ">
-		<div class="ui text loader">${properties['sendingMessage']}.</div>
+		<div class="ui text loader">${properties['sendingMessage'] || 'Sending e-mail...' @ i18n}.</div>
 	</div>
 
 	<div class="content scrolling">
@@ -49,20 +49,20 @@
 		<!--/* Messages after AJAX request */-->
 		<div data-asset-share-id="share-success"
 			 class="cmp-content--success">
-			<h3>${properties['successTitle']}</h3>
-			<p>${properties['successMessage']}</p>
+			<h3>${properties['successTitle'] || 'Success' @ i18n}</h3>
+			<p>${properties['successMessage'] || 'E-mail sent successfully' @ i18n}</p>
 		</div>
 		 <div data-asset-share-id="share-error"
 			  class="cmp-content--error">
-			<h3>${properties['errorTitle']}</h3>
-			<p>${properties['errorMessage']}</p>
+			<h3>${properties['errorTitle'] || 'Error' @ i18n}</h3>
+			<p>${properties['errorMessage'] || 'An error occurred while attempting to send the e-mail.' @ i18n}</p>
 		</div>
 		
 		<!--/* Email Share Form  */-->
 		<div class="ui grid cmp-content--form"
 			 data-asset-share-id="share-content">
 			<div class="four wide column">
-				<div class="ui header">${properties['assetListTitle']}</div>
+				<div class="ui header">${properties['assetListTitle'] || 'Assets' @ i18n}</div>
 
 				<div class="ui list" data-sly-list.asset="${share.assets}">
 					<div class="item">
@@ -75,22 +75,22 @@
 			</div>
 
 			<div class="eleven wide column">
-				<div class="ui header">${properties['shareOptionsTitle']}</div>
+				<div class="ui header">${properties['shareOptionsTitle'] || 'Share Options' @ i18n}</div>
 	
 				<sly data-sly-list.asset="${share.assets}">
 					<input type="hidden" name="path" value="${asset.path}" />
 				</sly>
 
 				<div class="field">
-					<label>${properties['emailFieldLabel']}</label>
+					<label>${properties['emailFieldLabel'] || 'E-mail Address' @ i18n}</label>
 					<input type="email" multiple name="email" required
-						   placeholder="${properties['emailPlaceholder']}"/>
+						   placeholder="${properties['emailPlaceholder'] || 'Comma delimited list of e-mail addresses' @ i18n}"/>
 				</div>
 
 				<div class="field">
-					<label>${properties['messageFieldLabel']}</label>
+					<label>${properties['messageFieldLabel'] || 'Message (optional)' @ i18n}</label>
 					<textarea rows="2" name="message"
-							placeholder="${properties['messagePlaceholder']}"></textarea>
+							placeholder="${properties['messagePlaceholder'] || 'Enter an optional message' @ i18n}"></textarea>
 				</div>
 			</div>
 		</div>
@@ -98,18 +98,18 @@
 	
 	<!--/* Default actions */-->
 	<div class="cmp-footer__actions actions">
-		<div class="ui deny button">${properties['cancelButton']}</div>
+		<div class="ui deny button">${properties['cancelButton'] || 'Cancel' @ i18n}</div>
 		<button data-asset-share-id="submit-share"
 				type="submit"
 				class="ui primary submit right labeled icon button">
-			${properties['shareButton']}
+			${properties['shareButton'] || 'Share' @ i18n}
 			<i class="send icon"></i>
 		</button>
 	</div>
 	
 	<!--/* After request actions */-->
 	<div class="cmp-footer__actions--completed actions">
-		<div class="ui deny button">${properties['closeButton']}</div>
+		<div class="ui deny button">${properties['closeButton'] || 'Close' @ i18n}</div>
 	</div>
 </form>
 

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/share/share.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/share/share.html
@@ -36,12 +36,12 @@
 	<i class="close icon"></i>
 
 	<div class="header">
-		${properties['modalTitle'] || 'Share' @ i18n}
+		${properties['modalTitle'] @ i18n}
 	</div>
 
 	<!--/* Loading */-->
 	<div class="cmp-content--loading ui inverted dimmer ">
-		<div class="ui text loader">${properties['sendingMessage'] || 'Sending e-mail...' @ i18n}.</div>
+		<div class="ui text loader">${properties['sendingMessage'] @ i18n}.</div>
 	</div>
 
 	<div class="content scrolling">
@@ -49,20 +49,20 @@
 		<!--/* Messages after AJAX request */-->
 		<div data-asset-share-id="share-success"
 			 class="cmp-content--success">
-			<h3>${properties['successTitle'] || 'Success' @ i18n}</h3>
-			<p>${properties['successMessage'] || 'E-mail sent successfully' @ i18n}</p>
+			<h3>${properties['successTitle'] @ i18n}</h3>
+			<p>${properties['successMessage'] @ i18n}</p>
 		</div>
 		 <div data-asset-share-id="share-error"
 			  class="cmp-content--error">
-			<h3>${properties['errorTitle'] || 'Error' @ i18n}</h3>
-			<p>${properties['errorMessage'] || 'An error occurred while attempting to send the e-mail.' @ i18n}</p>
+			<h3>${properties['errorTitle'] @ i18n}</h3>
+			<p>${properties['errorMessage'] @ i18n}</p>
 		</div>
 		
 		<!--/* Email Share Form  */-->
 		<div class="ui grid cmp-content--form"
 			 data-asset-share-id="share-content">
 			<div class="four wide column">
-				<div class="ui header">${properties['assetListTitle'] || 'Assets' @ i18n}</div>
+				<div class="ui header">${properties['assetListTitle'] @ i18n}</div>
 
 				<div class="ui list" data-sly-list.asset="${share.assets}">
 					<div class="item">
@@ -75,22 +75,22 @@
 			</div>
 
 			<div class="eleven wide column">
-				<div class="ui header">${properties['shareOptionsTitle'] || 'Share Options' @ i18n}</div>
+				<div class="ui header">${properties['shareOptionsTitle'] @ i18n}</div>
 	
 				<sly data-sly-list.asset="${share.assets}">
 					<input type="hidden" name="path" value="${asset.path}" />
 				</sly>
 
 				<div class="field">
-					<label>${properties['emailFieldLabel'] || 'E-mail Address' @ i18n}</label>
+					<label>${properties['emailFieldLabel'] @ i18n}</label>
 					<input type="email" multiple name="email" required
-						   placeholder="${properties['emailPlaceholder'] || 'Comma delimited list of e-mail addresses' @ i18n}"/>
+						   placeholder="${properties['emailPlaceholder'] @ i18n}"/>
 				</div>
 
 				<div class="field">
-					<label>${properties['messageFieldLabel'] || 'Message (optional)' @ i18n}</label>
+					<label>${properties['messageFieldLabel'] @ i18n}</label>
 					<textarea rows="2" name="message"
-							placeholder="${properties['messagePlaceholder'] || 'Enter an optional message' @ i18n}"></textarea>
+							placeholder="${properties['messagePlaceholder'] @ i18n}"></textarea>
 				</div>
 			</div>
 		</div>
@@ -98,18 +98,18 @@
 	
 	<!--/* Default actions */-->
 	<div class="cmp-footer__actions actions">
-		<div class="ui deny button">${properties['cancelButton'] || 'Cancel' @ i18n}</div>
+		<div class="ui deny button">${properties['cancelButton'] @ i18n}</div>
 		<button data-asset-share-id="submit-share"
 				type="submit"
 				class="ui primary submit right labeled icon button">
-			${properties['shareButton'] || 'Share' @ i18n}
+			${properties['shareButton'] @ i18n}
 			<i class="send icon"></i>
 		</button>
 	</div>
 	
 	<!--/* After request actions */-->
 	<div class="cmp-footer__actions--completed actions">
-		<div class="ui deny button">${properties['closeButton'] || 'Close' @ i18n}</div>
+		<div class="ui deny button">${properties['closeButton'] @ i18n}</div>
 	</div>
 </form>
 

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/date-range/templates/options.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/date-range/templates/options.html
@@ -24,7 +24,7 @@
             <div class="ui input left icon">
                 <i class="calendar icon"></i>
                 <input type="text"
-                       placeholder="${properties['startPlaceholder']}"
+                       placeholder="${properties['startPlaceholder'] @ i18n}"
                        name="${predicate.group}.${predicate.lowerBoundName}"
                        value="${predicate.initialLowerBound}"
                        form="${predicate.formId}"
@@ -38,7 +38,7 @@
             <div class="ui input left icon">
                 <i class="calendar icon"></i>
                 <input type="text"
-                       placeholder="${properties['endPlaceholder']}"
+                       placeholder="${properties['endPlaceholder'] @ i18n}"
                        name="${predicate.group}.${predicate.upperBoundName}"
                        value="${predicate.initialUpperBound}"
                        form="${predicate.formId}"

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/filter-toggle/templates/toggles.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/filter-toggle/templates/toggles.html
@@ -21,7 +21,7 @@
             form="${pagePredicate.formId}"
             class="ui icon fluid button ${hideLabels ? '' : 'labeled'}">
         <i class=" filter icon"></i>
-        <span data-sly-test="${!hideLabels}">${properties['applyFilterLabel'] || 'Apply' @ i18n}</span>
+        <span data-sly-test="${!hideLabels}">${properties['applyFilterLabel'] @ i18n}</span>
     </button>
 </template>
 
@@ -29,6 +29,6 @@
     <a class="ui icon fluid button ${hideLabels ? '' : 'labeled'}"
        href="${currentPage.path @ extension = 'html'}">
         <i class="undo icon"></i>
-        <span data-sly-test="${!hideLabels}">${properties['resetFilterLabel'] || 'Reset' @ i18n}</span>
+        <span data-sly-test="${!hideLabels}">${properties['resetFilterLabel'] @ i18n}</span>
     </a>
 </template>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/filter-toggle/templates/toggles.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/filter-toggle/templates/toggles.html
@@ -21,7 +21,7 @@
             form="${pagePredicate.formId}"
             class="ui icon fluid button ${hideLabels ? '' : 'labeled'}">
         <i class=" filter icon"></i>
-        <span data-sly-test="${!hideLabels}">${properties['applyFilterLabel']}</span>
+        <span data-sly-test="${!hideLabels}">${properties['applyFilterLabel'] || 'Apply' @ i18n}</span>
     </button>
 </template>
 
@@ -29,6 +29,6 @@
     <a class="ui icon fluid button ${hideLabels ? '' : 'labeled'}"
        href="${currentPage.path @ extension = 'html'}">
         <i class="undo icon"></i>
-        <span data-sly-test="${!hideLabels}">${properties['resetFilterLabel']}</span>
+        <span data-sly-test="${!hideLabels}">${properties['resetFilterLabel'] || 'Reset' @ i18n}</span>
     </a>
 </template>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/freeform-text/freeform-text.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/freeform-text/freeform-text.html
@@ -61,7 +61,7 @@
 
 				<div class="field">
                         <textarea type="text"
-                                  placeholder="${properties['placeholder']}"
+                                  placeholder="${properties['placeholder'] @ i18n}"
                                   minlength="${predicate.inputValidationMinLength}"
                                   maxlength="${predicate.inputValidationMaxLength}"
                                   pattern="${predicate.inputValidationPattern}"
@@ -75,7 +75,7 @@
                                   data-sly-test.isTextArea="${predicate.rows > 1}">${predicate.initialValue}</textarea>
 
                         <input type="text"
-                               placeholder="${properties['placeholder']}"
+                               placeholder="${properties['placeholder'] @ i18n}"
                                minlength="${predicate.inputValidationMinLength}"
                                maxlength="${predicate.inputValidationMaxLength}"
                                pattern="${predicate.inputValidationPattern}"

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/layout-toggle/layout-toggle.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/layout-toggle/layout-toggle.html
@@ -21,18 +21,18 @@
 		value="card"
 		data-asset-share-id="switch-layout">
 	<i class="big grid layout icon cmp-button__icon"
-	   title="${properties['cardLabel']}"></i>
+	   title="${properties['cardLabel'] || 'Card Toggle' @ i18n}"></i>
 	<span 	class="cmp-button__label"
 			data-sly-test.showLabels="${properties['showLabels']}"
-	      	data-sly-text="${properties['cardLabel']}"></span>
+	      	data-sly-text="${properties['cardLabel'] || 'Card Toggle' @ i18n}"></span>
 </button>
 
 <button class="ui icon button plain cmp-button ${properties['showLabels'] ? 'cmp-button--labeled' : ''}"
 		value="list"
 		data-asset-share-id="switch-layout">
 	<i class="big list layout icon cmp-button__icon"
-	   title="${properties['listLabel']}"></i>
+	   title="${properties['listLabel'] || 'List Toggle' @ i18n}"></i>
 	<span 	class="cmp-button__label"
 			data-sly-test="${showLabels}"
-	      	data-sly-text="${properties['listLabel']}"></span>
+	      	data-sly-text="${properties['listLabel'] || 'List Toggle' @ i18n}"></span>
 </button>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/layout-toggle/layout-toggle.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/layout-toggle/layout-toggle.html
@@ -21,18 +21,18 @@
 		value="card"
 		data-asset-share-id="switch-layout">
 	<i class="big grid layout icon cmp-button__icon"
-	   title="${properties['cardLabel'] || 'Card Toggle' @ i18n}"></i>
+	   title="${properties['cardLabel'] @ i18n}"></i>
 	<span 	class="cmp-button__label"
 			data-sly-test.showLabels="${properties['showLabels']}"
-	      	data-sly-text="${properties['cardLabel'] || 'Card Toggle' @ i18n}"></span>
+	      	data-sly-text="${properties['cardLabel'] @ i18n}"></span>
 </button>
 
 <button class="ui icon button plain cmp-button ${properties['showLabels'] ? 'cmp-button--labeled' : ''}"
 		value="list"
 		data-asset-share-id="switch-layout">
 	<i class="big list layout icon cmp-button__icon"
-	   title="${properties['listLabel'] || 'List Toggle' @ i18n}"></i>
+	   title="${properties['listLabel'] @ i18n}"></i>
 	<span 	class="cmp-button__label"
 			data-sly-test="${showLabels}"
-	      	data-sly-text="${properties['listLabel'] || 'List Toggle' @ i18n}"></span>
+	      	data-sly-text="${properties['listLabel'] @ i18n}"></span>
 </button>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/results/result/card/templates/card.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/results/result/card/templates/card.html
@@ -88,6 +88,6 @@
 
 <template data-sly-template.noResults="${@ search = search, config = config }">
     <h1 class="ui center aligned header">
-        ${properties['noResultsText'] || 'Your search did not match any assets.' @ i18n}
+        ${properties['noResultsText'] @ i18n}
     </h1>
 </template>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/results/result/card/templates/card.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/results/result/card/templates/card.html
@@ -88,6 +88,6 @@
 
 <template data-sly-template.noResults="${@ search = search, config = config }">
     <h1 class="ui center aligned header">
-        ${properties['noResultsText']}
+        ${properties['noResultsText'] || 'Your search did not match any assets.' @ i18n}
     </h1>
 </template>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/results/result/horizontal-masonry-card/templates/card.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/results/result/horizontal-masonry-card/templates/card.html
@@ -73,6 +73,6 @@
 
 <template data-sly-template.noResults="${@ search = search, config = config }">
     <h1 class="ui center aligned header">
-        ${properties['noResultsText'] || 'Your search did not match any assets.' @ i18n}
+        ${properties['noResultsText'] @ i18n}
     </h1>
 </template>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/results/result/horizontal-masonry-card/templates/card.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/results/result/horizontal-masonry-card/templates/card.html
@@ -73,6 +73,6 @@
 
 <template data-sly-template.noResults="${@ search = search, config = config }">
     <h1 class="ui center aligned header">
-        ${properties['noResultsText']}
+        ${properties['noResultsText'] || 'Your search did not match any assets.' @ i18n}
     </h1>
 </template>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/results/result/templates/common.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/results/result/templates/common.html
@@ -61,7 +61,7 @@
         <sly data-sly-test="${search.results.more}">
             <br/><br/>
             <button data-asset-share-id="${properties['infiniteLoadMore'] ? 'infinite-load-more' : 'load-more'}"
-                    class="fluid ui button">${properties['loadMoreLabel'] || 'Load more' @ i18n}</button>
+                    class="fluid ui button">${properties['loadMoreLabel'] @ i18n}</button>
         </sly>
     </div>
 </template>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/results/result/templates/common.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/results/result/templates/common.html
@@ -61,7 +61,7 @@
         <sly data-sly-test="${search.results.more}">
             <br/><br/>
             <button data-asset-share-id="${properties['infiniteLoadMore'] ? 'infinite-load-more' : 'load-more'}"
-                    class="fluid ui button">${properties['loadMoreLabel']}</button>
+                    class="fluid ui button">${properties['loadMoreLabel'] || 'Load more' @ i18n}</button>
         </sly>
     </div>
 </template>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/search-bar/search-bar.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/search-bar/search-bar.html
@@ -22,7 +22,7 @@
 
 	<div class="ui fluid big left icon input ${properties['hideButton'] ? '' : 'action'}">
 		<input type="${predicate.type}"
-			   placeholder="${properties['placeholder']}"
+			   placeholder="${properties['placeholder'] || 'What are you looking for?' @ i18n}"
 			   name="${predicate.name}"
 			   id="${predicate.id}"
 			   value="${predicate.initialValue}"
@@ -30,7 +30,7 @@
 		<i class="search icon"></i>
 		<button class="ui primary button ${properties['hideButton'] ? 'hidden' : ''}" 
 				form="${predicate.formId}">
-		        ${properties['buttonLabel']}
+		        ${properties['buttonLabel'] || 'Search' @ i18n}
 		</button>
 	</div>
 

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/search-bar/search-bar.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/search-bar/search-bar.html
@@ -22,7 +22,7 @@
 
 	<div class="ui fluid big left icon input ${properties['hideButton'] ? '' : 'action'}">
 		<input type="${predicate.type}"
-			   placeholder="${properties['placeholder'] || 'What are you looking for?' @ i18n}"
+			   placeholder="${properties['placeholder'] @ i18n}"
 			   name="${predicate.name}"
 			   id="${predicate.id}"
 			   value="${predicate.initialValue}"
@@ -30,7 +30,7 @@
 		<i class="search icon"></i>
 		<button class="ui primary button ${properties['hideButton'] ? 'hidden' : ''}" 
 				form="${predicate.formId}">
-		        ${properties['buttonLabel'] || 'Search' @ i18n}
+		        ${properties['buttonLabel'] @ i18n}
 		</button>
 	</div>
 

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/sort/sort.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/sort/sort.html
@@ -59,8 +59,8 @@
 		<i class="dropdown icon"></i>
 		<div class="text">${predicate.orderBySortLabel}</div>
 		<div class="menu">
-			<div class="item ${predicate.ascending ? 'selected' : ''}" data-value="asc">${properties['ascendingLabel']}</div>
-			<div class="item ${predicate.ascending ? '' : 'selected'}" data-value="desc">${properties['descendingLabel']}</div>
+			<div class="item ${predicate.ascending ? 'selected' : ''}" data-value="asc">${properties['ascendingLabel'] || 'Ascending' @ i18n}</div>
+			<div class="item ${predicate.ascending ? '' : 'selected'}" data-value="desc">${properties['descendingLabel'] || 'Descending' @ i18n}</div>
 		</div>
 	</div>
 

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/sort/sort.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/sort/sort.html
@@ -59,8 +59,8 @@
 		<i class="dropdown icon"></i>
 		<div class="text">${predicate.orderBySortLabel}</div>
 		<div class="menu">
-			<div class="item ${predicate.ascending ? 'selected' : ''}" data-value="asc">${properties['ascendingLabel'] || 'Ascending' @ i18n}</div>
-			<div class="item ${predicate.ascending ? '' : 'selected'}" data-value="desc">${properties['descendingLabel'] || 'Descending' @ i18n}</div>
+			<div class="item ${predicate.ascending ? 'selected' : ''}" data-value="asc">${properties['ascendingLabel'] @ i18n}</div>
+			<div class="item ${predicate.ascending ? '' : 'selected'}" data-value="desc">${properties['descendingLabel'] @ i18n}</div>
 		</div>
 	</div>
 

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/statistics/statistics.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/statistics/statistics.html
@@ -28,7 +28,7 @@
 				${component.runningTotal}
 			</div>
 			<div class="label">
-				${properties['runningTotalLabel'] || 'Displayed' @ i18n}
+				${properties['runningTotalLabel'] @ i18n}
 			</div>
 		</div>
 
@@ -37,7 +37,7 @@
 				${component.total}${component.hasMore ? '+' : '' @ i18n}
 			</div>
 			<div class="label">
-				${properties['totalLabel'] || 'Total' @ i18n}
+				${properties['totalLabel'] @ i18n}
 			</div>
 		</div>
 
@@ -47,7 +47,7 @@
 				${component.timeTaken}
 			</div>
 			<div class="label">
-				${properties['timeTakenLabel'] || 'Milliseconds' @ i18n}
+				${properties['timeTakenLabel'] @ i18n}
 			</div>
 		</div>
 	</div>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/statistics/statistics.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/statistics/statistics.html
@@ -28,7 +28,7 @@
 				${component.runningTotal}
 			</div>
 			<div class="label">
-				${properties['runningTotalLabel']}
+				${properties['runningTotalLabel'] || 'Displayed' @ i18n}
 			</div>
 		</div>
 
@@ -37,7 +37,7 @@
 				${component.total}${component.hasMore ? '+' : '' @ i18n}
 			</div>
 			<div class="label">
-				${properties['totalLabel']}
+				${properties['totalLabel'] || 'Total' @ i18n}
 			</div>
 		</div>
 
@@ -47,7 +47,7 @@
 				${component.timeTaken}
 			</div>
 			<div class="label">
-				${properties['timeTakenLabel']}
+				${properties['timeTakenLabel'] || 'Milliseconds' @ i18n}
 			</div>
 		</div>
 	</div>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/structure/user-menu/templates/profile.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/structure/user-menu/templates/profile.html
@@ -24,7 +24,7 @@
         <a class="ui left cmp-user__action"
            href="${currentStyle['logInLink']}"
            data-sly-test="${!loggedIn}">
-            ${currentStyle['logInLabel'] || 'Log In' @ i18n}
+            ${currentStyle['logInLabel'] @ i18n}
         </a>
     </span>
 
@@ -43,14 +43,14 @@
            data-asset-share-id="cmp-user-menu__profile-pic--unavailable"></i>
 
         <div class="cmp-user__message">
-            ${currentStyle['greeting'] || 'Hello, ' @ i18n} <span data-asset-share-id="cmp-user-menu__profile-display-name"></span>
+            ${currentStyle['greeting'] @ i18n} <span data-asset-share-id="cmp-user-menu__profile-display-name"></span>
 
             <br/>
 
             <a class="cmp-user__action"
                href="${currentStyle['logOutLink']}"
                data-asset-share-id="cmp-user-menu__logout-link">
-                ${currentStyle['logOutLabel'] || 'Log Out' @ i18n}
+                ${currentStyle['logOutLabel'] @ i18n}
             </a>
         </div>
     </span>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/structure/user-menu/templates/profile.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/structure/user-menu/templates/profile.html
@@ -24,7 +24,7 @@
         <a class="ui left cmp-user__action"
            href="${currentStyle['logInLink']}"
            data-sly-test="${!loggedIn}">
-            ${currentStyle['logInLabel']}
+            ${currentStyle['logInLabel'] || 'Log In' @ i18n}
         </a>
     </span>
 
@@ -43,14 +43,14 @@
            data-asset-share-id="cmp-user-menu__profile-pic--unavailable"></i>
 
         <div class="cmp-user__message">
-            ${currentStyle['greeting']} <span data-asset-share-id="cmp-user-menu__profile-display-name"></span>
+            ${currentStyle['greeting'] || 'Hello, ' @ i18n} <span data-asset-share-id="cmp-user-menu__profile-display-name"></span>
 
             <br/>
 
             <a class="cmp-user__action"
                href="${currentStyle['logOutLink']}"
                data-asset-share-id="cmp-user-menu__logout-link">
-                ${currentStyle['logOutLabel']}
+                ${currentStyle['logOutLabel'] || 'Log Out' @ i18n}
             </a>
         </div>
     </span>


### PR DESCRIPTION
I added @i18n to several components that were using properties from Dialogs or Policies without applying the I18N

## Description

- I took [downloads component](https://github.com/adobe/asset-share-commons/blob/261238d49c5e16b2e40f29f347c80801cd3c330f/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/downloads/downloads.html#L88) as an example and I added "@ i18n" to components that didn't have it, for instance the [cart component](https://github.com/adobe/asset-share-commons/blob/261238d49c5e16b2e40f29f347c80801cd3c330f/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/cart/cart.html#L87).
- Following the downloads component as an example I added the default literal that I could find in the corresponding _cq_template node.

## Related Issue

 #690 

## Motivation and Context

Add I18N to the components that were missing it.

## How Has This Been Tested?

- I deployed the Asset Share Commons site sample
- In the advanced tab of the _/content/asset-share-commons/en  I changed the property Language to German
- Navigated different parts of the site comparing texts

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/25983819/154255640-9dca3137-8f66-4903-862c-46baf405922d.png)

![image](https://user-images.githubusercontent.com/25983819/154291548-97530af2-2141-4b3b-98bf-0a4af80a0553.png)

## Types of changes

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ X] All new and existing tests passed.
