### PR TITLE
#0668 - Search bar component placeholder text not displaying until fo…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - 0677 - Fixed critical cloud manager errors
-
+- 0668 - Search bar component placeholder text not displaying until focused on light and dark themes
 
 ## [v2.1.12]
 

--- a/ui.frontend.theme.dark/semanticui/site/elements/input.variables
+++ b/ui.frontend.theme.dark/semanticui/site/elements/input.variables
@@ -1,3 +1,4 @@
 @focusBorderColor: @primaryColor;
 @focusBoxShadow: none;
 @border: @borderWidth solid @fullBlack;
+@placeholderColor: @placeholderFocusColor;

--- a/ui.frontend.theme.light/semanticui/site/elements/input.variables
+++ b/ui.frontend.theme.light/semanticui/site/elements/input.variables
@@ -1,2 +1,3 @@
 @focusBorderColor: @primaryColor;
 @focusBoxShadow: none;
+@placeholderColor: @placeholderFocusColor;


### PR DESCRIPTION
…cused on light and dark themes

Fixed issue in light/dark themes where  the placeholder text was not displaying in the search field (or any textfield i think) until that field received focus.


## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
