### PR TITLE
0716 - adds jcr:read to everyone on /libs/.../mimeTypeLookup on publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed 
+
+- 0716 - Fixes issue with mimeTypeLookup node not being accessible to everyone on publish
+
+
 ## [v2.2.2]
 
 ### Fixed

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/config.publish/org.apache.sling.jcr.repoinit.RepositoryInitializer-asset-share-commons-publish.config
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/config.publish/org.apache.sling.jcr.repoinit.RepositoryInitializer-asset-share-commons-publish.config
@@ -1,0 +1,6 @@
+scripts=["
+    set ACL on /libs/dam/gui/content/assets/jcr:content/mimeTypeLookup
+        allow jcr:read for everyone
+    end
+"]
+

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/resources/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/resources/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:Folder"/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Uses repo init script to make /libs/dam/gui/content/assets/jcr:content/mimeTypeLookup jcr:read for everyone on AEM Publish, allowing the AssetType computed property to work on AEM Publish.

We can decide if want to include this along w/ the updated asset details resolution scheme (to keep back-compat for assetType)


<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
