### PR TITLE
Embed ACS AEM Commons sources and recompile

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -31,6 +31,58 @@
                 <groupId>org.apache.sling</groupId>
                 <artifactId>sling-maven-plugin</artifactId>
             </plugin>
+            <!-- copy some Java source files from ACS AEM Commons for embedding them here -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>com.adobe.acs</groupId>
+                                    <artifactId>acs-aem-commons-bundle</artifactId>
+                                    <version>5.3.0</version>
+                                    <classifier>sources</classifier>
+                                    <type>jar</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}/generated-sources/acs-aem-commons</outputDirectory>
+                                    <includes>com/adobe/acs/commons/util/Buffered*.java,
+                                        java,com/adobe/acs/commons/util/Servlet*.java,
+                                        java,com/adobe/acs/commons/util/PathInfoUtil*.java,
+                                        java,com/adobe/acs/commons/util/ParameterUtil*.java</includes>
+                                </artifactItem>
+                            </artifactItems>
+                            <includes>**/*.java</includes>
+                            <overWriteReleases>false</overWriteReleases>
+                            <overWriteSnapshots>true</overWriteSnapshots>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-source</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.build.directory}/generated-sources/acs-aem-commons</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-maven-plugin</artifactId>
@@ -48,9 +100,7 @@ com.adobe.aem.commons.assetshare.content.impl,\
 com.adobe.aem.commons.assetshare.search.impl,\
 com.adobe.aem.commons.assetshare.search.results.impl.result,\
 com.adobe.aem.commons.assetshare.util.impl
-# conditionalpackage is too coarse, as it will drag in all transitive deps of arbitrary classes in one package, only embed specific classes
--includeresource: @acs-aem-commons-bundle-[0-9.]*.jar!/com/adobe/acs/commons/util/(BufferedSlingHttpServletResponse|PathInfoUtil|ParameterUtil).*,\
-                            ]]></bnd>
+                     ]]></bnd>
                 </configuration>
             </plugin>
             <plugin>
@@ -125,11 +175,6 @@ com.adobe.aem.commons.assetshare.util.impl
             <groupId>com.adobe.cq</groupId>
             <artifactId>core.wcm.components.core</artifactId>
             <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.adobe.acs</groupId>
-            <artifactId>acs-aem-commons-bundle</artifactId>
-            <scope>provided</scope><!-- should not transitively be exposed -->
         </dependency>
         <!-- JDK 11 -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -427,7 +427,6 @@ Bundle-DocURL: https://opensource.adobe.com/asset-share-commons/
                                         </versionRange>
                                         <goals>
                                             <goal>copy-dependencies</goal>
-                                            <goal>unpack</goal>
                                         </goals>
                                     </pluginExecutionFilter>
                                     <action>

--- a/pom.xml
+++ b/pom.xml
@@ -940,19 +940,6 @@ Bundle-DocURL: https://opensource.adobe.com/asset-share-commons/
                 <version>3.0.0</version><!-- cannot use newer version due to https://github.com/amaembo/jsr-305/issues/31, todo: switch to Jetbrains annotation -->
                 <scope>compile</scope>
             </dependency>
-            <!-- Embedded dependency -->
-            <dependency>
-                <groupId>com.adobe.acs</groupId>
-                <artifactId>acs-aem-commons-bundle</artifactId>
-                <version>5.3.0</version>
-                <scope>compile</scope>
-                <exclusions>
-                    <exclusion>
-                        <groupId>*</groupId>
-                        <artifactId>*</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
             <!-- JDK 11 -->
             <dependency>
                 <artifactId>org.apache.sling.javax.activation</artifactId>


### PR DESCRIPTION
This ensures that all necessary transitive classes are embedded as well This closes #834

<!--- Provide a general summary of your changes in the Title above -->

Unfortunately I was not able to reproduce the bug locally. @dsandqui Please give it a try.