### PR TITLE
Replace deprecated set-output command with >> $GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -63,8 +63,7 @@ jobs:
 
       - name: Store Version
         id: store-version
-        run: echo "::set-output name=version::$(grep ^scm.tag= release.properties | sed -e 's/scm.tag=asset-share-commons-//g')"
-
+        run: echo "version=$(grep ^scm.tag= release.properties | sed -e 's/scm.tag=asset-share-commons-//g')" >> $GITHUB_OUTPUT
   Github_Release:
     needs: Tag
     runs-on: ubuntu-latest


### PR DESCRIPTION

## Description

Fixes deprecation notices reported at: https://github.com/adobe/asset-share-commons/actions/runs/3347887669

## Related Issue

N/A

## Motivation and Context

Github warning that deprecated methods will be removed.

## How Has This Been Tested?

Not yet! 

## Screenshots (if appropriate):

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
