### PR TITLE
HTML email values are being double-encoded in the Share email

### DIFF
--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/share/impl/EmailShareServiceImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/actions/share/impl/EmailShareServiceImpl.java
@@ -127,6 +127,7 @@ public class EmailShareServiceImpl implements ShareService {
         final EmailShare emailShare = request.adaptTo(EmailShare.class);
 
         shareParameters.putAll(xssProtectUserData(emailShare.getUserData()));
+        //shareParameters.putAll(emailShare.getUserData());
 
         // Configured data supersedes user data
         shareParameters.putAll(emailShare.getConfiguredData());
@@ -301,13 +302,13 @@ public class EmailShareServiceImpl implements ShareService {
     private String[] xssCleanData(String[] dirtyData) {
         List<String> cleanValues = new ArrayList<String>();
         for (String val : dirtyData) {
-            cleanValues.add(xssAPI.encodeForHTML(xssAPI.filterHTML(val)));
+            cleanValues.add(xssAPI.encodeForHTML(val));
         }
         return cleanValues.toArray(new String[0]);
     }
 
     private String xssCleanData(String dirtyData) {
-        return xssAPI.encodeForHTML(xssAPI.filterHTML(dirtyData));
+        return xssAPI.encodeForHTML(dirtyData);
     }
 
     @Activate


### PR DESCRIPTION
Email are double-encoding characters such as `&`.

## Description

When a share description of `hello & world` is added, the share emails displays `hello &amp; world`. This is due to double encoding of data.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Sent myself a test email after the fix:

## Screenshots (if appropriate):

![2023-01-09 at 11 42 AM](https://user-images.githubusercontent.com/1451868/211360985-77c50dfb-f357-4f84-8db2-71f729b1aa56.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
