### PR TITLE
feature/metadata json lookup

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.adobe.aem.commons</groupId>
         <artifactId>assetshare</artifactId>
-        <version>2.6.7-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core.cloud/pom.xml
+++ b/core.cloud/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.adobe.aem.commons</groupId>
         <artifactId>assetshare</artifactId>
-        <version>2.6.7-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>assetshare.core.cloud</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.adobe.aem.commons</groupId>
         <artifactId>assetshare</artifactId>
-        <version>2.6.7-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>assetshare.core</artifactId>

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/Metadata.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/Metadata.java
@@ -69,7 +69,7 @@ public interface Metadata extends EmptyTextComponent {
     String getLocale();
 
     /**
-     *
+     * Get the display text using a json file
      * @return
      * @throws IOException
      */

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/Metadata.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/Metadata.java
@@ -24,6 +24,9 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.ValueMap;
 import org.osgi.annotation.versioning.ConsumerType;
 
+import java.io.IOException;
+import java.util.List;
+
 @ConsumerType
 public interface Metadata extends EmptyTextComponent {
 
@@ -65,12 +68,19 @@ public interface Metadata extends EmptyTextComponent {
      */
     String getLocale();
 
+    /**
+     *
+     * @return
+     * @throws IOException
+     */
+    List<String> getDisplayTextFromJson() throws IOException;
+
 
     /**
      * The DataType are the types of data supported by the Metadata Component that support special formatting.
      */
     enum DataType {
-        COMPUTED("computed"), TEXT("text"), DATE("date"), NUMBER("number"), BOOLEAN("boolean");
+        COMPUTED("computed"), TEXT("text"), DATE("date"), NUMBER("number"), BOOLEAN("boolean"), JSON_DATASOURCE("jsonDataSource");
 
         private String value;
 

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/Metadata.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/Metadata.java
@@ -69,18 +69,15 @@ public interface Metadata extends EmptyTextComponent {
     String getLocale();
 
     /**
-     * Get the display text using a json file
-     * @return
-     * @throws IOException
+     * @return the values for the selected property adn type
      */
-    List<String> getDisplayTextFromJson() throws IOException;
-
+    List<String> getValues() throws IOException;
 
     /**
      * The DataType are the types of data supported by the Metadata Component that support special formatting.
      */
     enum DataType {
-        COMPUTED("computed"), TEXT("text"), DATE("date"), NUMBER("number"), BOOLEAN("boolean"), JSON_DATASOURCE("jsonDataSource");
+        COMPUTED("computed"), TEXT("text"), DATE("date"), NUMBER("number"), BOOLEAN("boolean"), JSON("json");
 
         private String value;
 

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/impl/MetadataImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/impl/MetadataImpl.java
@@ -24,16 +24,16 @@ import com.adobe.aem.commons.assetshare.content.AssetModel;
 import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.export.json.ExporterConstants;
 import com.adobe.cq.sightly.SightlyWCMMode;
+import com.day.cq.dam.commons.util.DamUtil;
 import com.day.cq.wcm.api.Page;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
-import org.apache.sling.api.resource.Resource;
-import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.models.annotations.DefaultInjectionStrategy;
 import org.apache.sling.models.annotations.Exporter;
@@ -45,6 +45,7 @@ import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
 import com.day.cq.dam.api.Asset;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import javax.annotation.Nonnull;
 import javax.annotation.PostConstruct;
 import java.io.BufferedReader;
@@ -100,7 +101,7 @@ public class MetadataImpl extends AbstractEmptyTextComponent implements Metadata
     private String typeString;
 
     @ValueMapValue
-    private String jsonDataSourceProperty;
+    private String jsonSource;
 
     private DataType type;
 
@@ -110,6 +111,8 @@ public class MetadataImpl extends AbstractEmptyTextComponent implements Metadata
      * ValueMap of the properties of the Asset currently being viewed
      */
     private ValueMap combinedProperties;
+
+    private List<String> values = null;
 
     @PostConstruct
     public void init() {
@@ -172,6 +175,8 @@ public class MetadataImpl extends AbstractEmptyTextComponent implements Metadata
     public boolean isEmpty() {
         if (StringUtils.isBlank(getPropertyName())) {
             return true;
+        } else if (DataType.JSON.equals(getType())) {
+            return CollectionUtils.isEmpty(getValues());
         } else {
             Object val = combinedProperties.get(getPropertyName());
             if (val == null) {
@@ -203,74 +208,80 @@ public class MetadataImpl extends AbstractEmptyTextComponent implements Metadata
         return RESOURCE_TYPE;
     }
 
+
     @Override
-    public List<String> getDisplayTextFromJson() throws IOException {
-        List<String> metadataValue = Collections.EMPTY_LIST;
-        Object val = combinedProperties.get(getPropertyName());
-        if (null == val) {
-            return metadataValue;
-        } else if (val instanceof String) {
-            metadataValue = new ArrayList<>();
-            metadataValue.add((String) val);
-        } else if (val instanceof String[]) {
-            metadataValue = Arrays.asList((String[]) val);
+    public List<String> getValues() {
+        if (values == null) {
+            values = new ArrayList<>();
+
+            Object val = combinedProperties.get(getPropertyName());
+
+            if (null == val) {
+                return values;
+            } else if (val instanceof String) {
+                values.add((String) val);
+            } else if (val instanceof String[]) {
+                values.addAll(Arrays.asList((String[]) val));
+            }
+
+            if (DataType.JSON.equals(getType())) {
+                Asset asset = DamUtil.resolveToAsset(request.getResourceResolver().getResource(jsonSource));
+                if (null != asset) {
+                    try {
+                        values = readJson(values, asset);
+                    } catch (IOException e) {
+                        log.error("Unable to read JSON from [ {} ]. Defaulting to no values.", asset.getPath(), e);
+                    }
+                }
+            }
         }
-        ResourceResolver resolver = request.getResourceResolver();
-        Resource resource = resolver.getResource(jsonDataSourceProperty);
-        if (null == resource) {
-            return metadataValue;
-        }
-        Asset asset = resource.adaptTo(Asset.class);
-        if (null == asset) {
-            return metadataValue;
-        }
-        List<String> displayText = readJson(metadataValue, asset );
-        return displayText;
+
+        return values;
     }
 
     /**
-     *
-     * @param metadataValue
-     * @param asset
-     * @return displayText
+     * @param metadataValues the values from the metadata that will be used as the keys to look up values in the JSON
+     * @param jsonAsset      the asset that contains the JSON
+     * @return values the values from the JSON
      * @throws IOException
      */
-    private static List<String> readJson(List<String> metadataValue, Asset asset) throws IOException {
-        List<String> displayText = new ArrayList<>();
-        try (InputStream stream = asset.getOriginal().adaptTo(InputStream.class);
+    private List<String> readJson(List<String> metadataValues, Asset jsonAsset) throws IOException {
+        List<String> values = new ArrayList<>();
+        try (InputStream stream = jsonAsset.getOriginal().adaptTo(InputStream.class);
              BufferedReader reader = new BufferedReader(
                      new InputStreamReader(stream, StandardCharsets.UTF_8))) {
             Gson gson = new Gson();
             JsonObject jsonObject = gson.fromJson(reader, JsonObject.class);
-            if(jsonObject.isJsonObject()){
+            if (jsonObject.isJsonObject()) {
                 JsonElement optionsJson = jsonObject.get("options");
                 if (null == optionsJson) {
                     if (log.isDebugEnabled()) {
-                        log.debug("JSON is missing options array [ {} ]", asset.getPath());
+                        log.debug("JSON is missing options array [ {} ]", jsonAsset.getPath());
                     }
-                    return metadataValue;
+                    return metadataValues;
                 }
-                Type listType = new TypeToken<List<Option>>() {}.getType();
-                List<Option> options = gson.fromJson(optionsJson, listType);
-                for (String val : metadataValue) {
-                    Option value = options.stream()
+                Type listType = new TypeToken<List<JsonOption>>() {}.getType();
+
+                List<JsonOption> options = gson.fromJson(optionsJson, listType);
+
+                for (String val : metadataValues) {
+                    JsonOption value = options.stream()
                             .filter(option -> val.equals(option.value))
                             .findFirst()
                             .orElse(null);
-                    if( null!= value) {
-                        displayText.add(value.text);
-                    }
-                    else{
-                        displayText.add(val);
+                    if (null != value) {
+                        values.add(value.text);
+                    } else {
+                        values.add(val);
                     }
                 }
             }
 
         }
-        return displayText;
+        return values;
     }
 
-    protected class Option{
+    protected class JsonOption {
         private String text;
         private String value;
     }

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/package-info.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/package-info.java
@@ -14,7 +14,7 @@
  *
  */
 
-@Version("1.3.1")
+@Version("2.0.0")
 package com.adobe.aem.commons.assetshare.components.details;
 
 import org.osgi.annotation.versioning.Version;

--- a/dispatcher/pom.xml
+++ b/dispatcher/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.adobe.aem.commons</groupId>
         <artifactId>assetshare</artifactId>
-        <version>2.6.7-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <groupId>com.adobe.aem.commons</groupId>
     <artifactId>assetshare</artifactId>
     <packaging>pom</packaging>
-    <version>2.6.7-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
 
     <name>Asset Share Commons - Reactor Project</name>
     <description>asset-share-commons</description>

--- a/ui.apps.structure/pom.xml
+++ b/ui.apps.structure/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.adobe.aem.commons</groupId>
         <artifactId>assetshare</artifactId>
-        <version>2.6.7-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ui.apps/pom.xml
+++ b/ui.apps/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.adobe.aem.commons</groupId>
         <artifactId>assetshare</artifactId>
-        <version>2.6.7-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/metadata/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/metadata/_cq_dialog/.content.xml
@@ -107,6 +107,10 @@
                                                     jcr:primaryType="nt:unstructured"
                                                     text="Boolean"
                                                     value="boolean"/>
+                                            <jsonDataSource
+                                                    jcr:primaryType="nt:unstructured"
+                                                    text="JSON DataSource"
+                                                    value="jsonDataSource"/>
                                         </items>
                                     </data-type>
                                     <set-date
@@ -263,6 +267,36 @@
                                             </well>
                                         </items>
                                     </set-computed>
+                                    <set-jsonDataSource
+                                            granite:class="hide list-option-listfrom-showhide-target foundation-layout-util-vmargin"
+                                            jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="granite/ui/components/coral/foundation/container">
+                                        <granite:data
+                                                jcr:primaryType="nt:unstructured"
+                                                showhidetargetvalue="jsonDataSource"/>
+                                        <items jcr:primaryType="nt:unstructured">
+                                            <heading
+                                                    jcr:primaryType="nt:unstructured"
+                                                    sling:resourceType="granite/ui/components/coral/foundation/heading"
+                                                    level="{Long}4"
+                                                    text="JSON DataSource File to fetch Display Text from"/>
+                                            <well
+                                                    jcr:primaryType="nt:unstructured"
+                                                    sling:resourceType="granite/ui/components/coral/foundation/well">
+                                                <items jcr:primaryType="nt:unstructured">
+                                                    <jsonDataSource
+                                                            jcr:primaryType="nt:unstructured"
+                                                            sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
+                                                            fieldDescription="A JSON file having an options array with text and value properties used in metadata schema to populate dropdown fields"
+                                                            fieldLabel="JSON DataSource"
+                                                            name="./jsonDataSourceProperty"
+                                                            rootPath="/content/dam"
+                                                            required="{Boolean}true">
+                                                    </jsonDataSource>
+                                                </items>
+                                            </well>
+                                        </items>
+                                    </set-jsonDataSource>
                                 </items>
                             </column>
                         </items>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/metadata/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/metadata/_cq_dialog/.content.xml
@@ -107,10 +107,10 @@
                                                     jcr:primaryType="nt:unstructured"
                                                     text="Boolean"
                                                     value="boolean"/>
-                                            <jsonDataSource
+                                            <json
                                                     jcr:primaryType="nt:unstructured"
-                                                    text="JSON DataSource"
-                                                    value="jsonDataSource"/>
+                                                    text="JSON"
+                                                    value="json"/>
                                         </items>
                                     </data-type>
                                     <set-date
@@ -273,7 +273,7 @@
                                             sling:resourceType="granite/ui/components/coral/foundation/container">
                                         <granite:data
                                                 jcr:primaryType="nt:unstructured"
-                                                showhidetargetvalue="jsonDataSource"/>
+                                                showhidetargetvalue="json"/>
                                         <items jcr:primaryType="nt:unstructured">
                                             <heading
                                                     jcr:primaryType="nt:unstructured"

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/metadata/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/metadata/_cq_dialog/.content.xml
@@ -267,7 +267,7 @@
                                             </well>
                                         </items>
                                     </set-computed>
-                                    <set-jsonDataSource
+                                    <set-json
                                             granite:class="hide list-option-listfrom-showhide-target foundation-layout-util-vmargin"
                                             jcr:primaryType="nt:unstructured"
                                             sling:resourceType="granite/ui/components/coral/foundation/container">
@@ -279,24 +279,24 @@
                                                     jcr:primaryType="nt:unstructured"
                                                     sling:resourceType="granite/ui/components/coral/foundation/heading"
                                                     level="{Long}4"
-                                                    text="JSON DataSource File to fetch Display Text from"/>
+                                                    text="JSON lookup file"/>
                                             <well
                                                     jcr:primaryType="nt:unstructured"
                                                     sling:resourceType="granite/ui/components/coral/foundation/well">
                                                 <items jcr:primaryType="nt:unstructured">
-                                                    <jsonDataSource
+                                                    <json
                                                             jcr:primaryType="nt:unstructured"
                                                             sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
-                                                            fieldDescription="A JSON file having an options array with text and value fields"
+                                                            fieldDescription="A JSON file having an options array with text and value fields."
                                                             fieldLabel="JSON DataSource"
-                                                            name="./jsonDataSourceProperty"
+                                                            name="./jsonSource"
                                                             rootPath="/content/dam"
                                                             required="{Boolean}true">
-                                                    </jsonDataSource>
+                                                    </json>
                                                 </items>
                                             </well>
                                         </items>
-                                    </set-jsonDataSource>
+                                    </set-json>
                                 </items>
                             </column>
                         </items>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/metadata/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/metadata/_cq_dialog/.content.xml
@@ -287,7 +287,7 @@
                                                     <jsonDataSource
                                                             jcr:primaryType="nt:unstructured"
                                                             sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
-                                                            fieldDescription="A JSON file having an options array with text and value properties used in metadata schema to populate dropdown fields"
+                                                            fieldDescription="A JSON file having an options array with text and value fields"
                                                             fieldLabel="JSON DataSource"
                                                             name="./jsonDataSourceProperty"
                                                             rootPath="/content/dam"

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/metadata/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/metadata/_cq_dialog/.content.xml
@@ -288,7 +288,7 @@
                                                             jcr:primaryType="nt:unstructured"
                                                             sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
                                                             fieldDescription="A JSON file having an options array with text and value fields."
-                                                            fieldLabel="JSON DataSource"
+                                                            fieldLabel="JSON"
                                                             name="./jsonSource"
                                                             rootPath="/content/dam"
                                                             required="{Boolean}true">

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/metadata/metadata.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/metadata/metadata.html
@@ -46,6 +46,9 @@
 
             <sly data-sly-test="${field.type.value == 'boolean'}"
                  data-sly-call="${fieldTypesTemplate.boolean @ field = field}"></sly>
+
+            <sly data-sly-test="${field.type.value == 'jsonDataSource'}"
+                 data-sly-call="${fieldTypesTemplate.json @ field = field}"></sly>
         </sly>
     </div>
 

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/metadata/metadata.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/metadata/metadata.html
@@ -47,7 +47,7 @@
             <sly data-sly-test="${field.type.value == 'boolean'}"
                  data-sly-call="${fieldTypesTemplate.boolean @ field = field}"></sly>
 
-            <sly data-sly-test="${field.type.value == 'jsonDataSource'}"
+            <sly data-sly-test="${field.type.value == 'json'}"
                  data-sly-call="${fieldTypesTemplate.json @ field = field}"></sly>
         </sly>
     </div>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/metadata/templates/field-types.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/metadata/templates/field-types.html
@@ -48,3 +48,12 @@
     <p data-sly-test.truthy="${field.properties[field.propertyName]}">${properties['trueValue'] || 'Yes' @ i18n}</p>
     <p data-sly-test="${!truthy}">${properties['falseValue'] || 'No' @ i18n}</p>
 </template>
+
+<!--/* JSON Lookup */-->
+<template data-sly-template.json="${@ field}">
+    <sly data-sly-list="${field.displayTextFromJson}">
+        <div class="item">
+            ${item}
+        </div>
+    </sly>
+</template>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/metadata/templates/field-types.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/metadata/templates/field-types.html
@@ -51,7 +51,7 @@
 
 <!--/* JSON Lookup */-->
 <template data-sly-template.json="${@ field}">
-    <sly data-sly-list="${field.displayTextFromJson}">
+    <sly data-sly-list="${field.values}">
         <div class="item">
             ${item}
         </div>

--- a/ui.config/pom.xml
+++ b/ui.config/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.adobe.aem.commons</groupId>
         <artifactId>assetshare</artifactId>
-        <version>2.6.7-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ui.content.sample/pom.xml
+++ b/ui.content.sample/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.adobe.aem.commons</groupId>
         <artifactId>assetshare</artifactId>
-        <version>2.6.7-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ui.content/pom.xml
+++ b/ui.content/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.adobe.aem.commons</groupId>
         <artifactId>assetshare</artifactId>
-        <version>2.6.7-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ui.frontend.theme.dark/pom.xml
+++ b/ui.frontend.theme.dark/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.adobe.aem.commons</groupId>
         <artifactId>assetshare</artifactId>
-        <version>2.6.7-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ui.frontend.theme.light/pom.xml
+++ b/ui.frontend.theme.light/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.adobe.aem.commons</groupId>
         <artifactId>assetshare</artifactId>
-        <version>2.6.7-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
1. Added JSONDataSource to the Metadata Type dropdown of Metadata Component
<img width="609" alt="Screenshot 2023-06-08 at 9 01 33 PM" src="https://github.com/adobe/asset-share-commons/assets/34283439/4cbfcce2-dbf5-468f-9c96-117d4874d059">

3.  Which when selected displays a field to select a path to a json file in the DAM
4.  Format of the json needs to be as below
```
{
  "options": [
    {
      "text": "Lorem ipsum",
      "value": "lorem-ipsum"
    },
    {
      "text": "Vestibulum efficitur",
      "value": "vestibulum-efficitur"
    }]
}
```
5. When configured, the text in the above json is used as display text in the metadata component instead of actual value that gets stored in the JCR