### PR TITLE
Added tighter restrictions on what mimetypes can use the AssetDeliver…

### DIFF
--- a/core.cloud/src/main/java/com/adobe/aem/commons/assetshare/content/renditions/impl/dispatchers/AssetDeliveryRenditionDispatcherImpl.java
+++ b/core.cloud/src/main/java/com/adobe/aem/commons/assetshare/content/renditions/impl/dispatchers/AssetDeliveryRenditionDispatcherImpl.java
@@ -72,6 +72,12 @@ public class AssetDeliveryRenditionDispatcherImpl extends AbstractRenditionDispa
     public static final String PN_FORMAT = "format";
     public static final String PN_SEONAME = "seoname";
     public static final String DEFAULT_FORMAT = "webp";
+    final String[] ACCEPTED_MIME_TYPES = {
+            "image/.*",
+            "application/pdf",
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation",    // PPT
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",      // DOC
+    };
 
     private Cfg cfg;
 
@@ -223,9 +229,10 @@ public class AssetDeliveryRenditionDispatcherImpl extends AbstractRenditionDispa
         }
 
         // Asset Delivery only supports image and document formats; it cannot generate renditions for video, audio, etc. at this time.
-        final String[] allowedFormats = { "image/", "application/" };
         final String assetFormat = StringUtils.lowerCase(assetModel.getProperties().get(DamConstants.DC_FORMAT, String.class));
-        return StringUtils.startsWithAny(assetFormat, allowedFormats);
+
+        // Return true if assetFormat matches any regex in ALLOWED_MIME_TYPES
+        return Arrays.stream(ACCEPTED_MIME_TYPES).anyMatch(regex -> assetFormat.matches(regex));
     }
 
     protected String evaluateExpression(final SlingHttpServletRequest request, String expression) {


### PR DESCRIPTION
…yRenditionDispatcherImpl

It was reported that `application/x-subrip` were returning 404 on thumbnail requests, since `application/.*` was acted for web optimized delivery. 

Updated the list of allowed mimetypes to be:

```
    final String[] ACCEPTED_MIME_TYPES = {
            "image/.*",
            "application/pdf",
            "application/vnd.openxmlformats-officedocument.presentationml.presentation",    // PPT
            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",      // DOC
    };
```
Which are currently known to work.


<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
