### PR TITLE
Feature/metadata filter dropdown option

### DIFF
--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/PropertyPredicateImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/PropertyPredicateImpl.java
@@ -19,18 +19,22 @@
 
 package com.adobe.aem.commons.assetshare.components.predicates.impl;
 
-import com.adobe.aem.commons.assetshare.components.predicates.AbstractPredicate;
-import com.adobe.aem.commons.assetshare.components.predicates.PropertyPredicate;
-import com.adobe.aem.commons.assetshare.components.predicates.impl.options.SelectedOptionItem;
-import com.adobe.aem.commons.assetshare.components.predicates.impl.options.UnselectedOptionItem;
-import com.adobe.aem.commons.assetshare.search.impl.predicateevaluators.PropertyValuesPredicateEvaluator;
-import com.adobe.aem.commons.assetshare.util.PredicateUtil;
-import com.adobe.cq.export.json.ComponentExporter;
-import com.adobe.cq.export.json.ExporterConstants;
-import com.adobe.cq.wcm.core.components.models.form.OptionItem;
-import com.adobe.cq.wcm.core.components.models.form.Options;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.PostConstruct;
+import javax.inject.Named;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.models.annotations.Default;
 import org.apache.sling.models.annotations.DefaultInjectionStrategy;
@@ -40,151 +44,231 @@ import org.apache.sling.models.annotations.Required;
 import org.apache.sling.models.annotations.injectorspecific.Self;
 import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
 
-import javax.annotation.Nonnull;
-import javax.annotation.PostConstruct;
-import javax.inject.Named;
-import java.util.ArrayList;
-import java.util.List;
+import com.adobe.aem.commons.assetshare.components.predicates.AbstractPredicate;
+import com.adobe.aem.commons.assetshare.components.predicates.PropertyPredicate;
+import com.adobe.aem.commons.assetshare.components.predicates.impl.options.JsonOptionItem;
+import com.adobe.aem.commons.assetshare.components.predicates.impl.options.SelectedOptionItem;
+import com.adobe.aem.commons.assetshare.components.predicates.impl.options.UnselectedOptionItem;
+import com.adobe.aem.commons.assetshare.search.impl.predicateevaluators.PropertyValuesPredicateEvaluator;
+import com.adobe.aem.commons.assetshare.util.PredicateUtil;
+import com.adobe.cq.export.json.ComponentExporter;
+import com.adobe.cq.export.json.ExporterConstants;
+import com.adobe.cq.wcm.core.components.models.form.OptionItem;
+import com.adobe.cq.wcm.core.components.models.form.Options;
+import com.day.cq.dam.api.Asset;
+import com.day.cq.dam.commons.util.DamUtil;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.reflect.TypeToken;
 
 @Model(
-        adaptables = {SlingHttpServletRequest.class},
-        adapters = {PropertyPredicate.class, ComponentExporter.class},
-        resourceType = {PropertyPredicateImpl.RESOURCE_TYPE},
-        defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL
-)
+		adaptables = {SlingHttpServletRequest.class},
+		adapters = {PropertyPredicate.class, ComponentExporter.class},
+		resourceType = {PropertyPredicateImpl.RESOURCE_TYPE},
+		defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL
+		)
 @Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME, extensions = ExporterConstants.SLING_MODEL_EXTENSION)
 public class PropertyPredicateImpl extends AbstractPredicate implements PropertyPredicate, Options {
 
-    protected static final String RESOURCE_TYPE = "asset-share-commons/components/search/property";
-    protected static final String PN_TYPE = "type";
+	protected static final String RESOURCE_TYPE = "asset-share-commons/components/search/property";
+	protected static final String PN_TYPE = "type";
+	protected String valueFromRequest = null;
+	protected ValueMap valuesFromRequest = null;
+	protected static final String DAM_RESOURCE_TYPE = "dam:Asset";
+	@Self
+	@Required
+	private SlingHttpServletRequest request;
 
-    protected String valueFromRequest = null;
-    protected ValueMap valuesFromRequest = null;
+	@Self
+	@Required
+	private Options coreOptions;
 
-    @Self
-    @Required
-    private SlingHttpServletRequest request;
+	@ValueMapValue
+	private String label;
 
-    @Self
-    @Required
-    private Options coreOptions;
+	@ValueMapValue
+	private String property;
 
-    @ValueMapValue
-    private String label;
+	@ValueMapValue
+	private String operation;
 
-    @ValueMapValue
-    private String property;
+	@ValueMapValue
+	private Boolean expanded;
 
-    @ValueMapValue
-    private String operation;
+	@ValueMapValue(name = PropertyPredicateImpl.PN_TYPE)
+	private String typeString;
 
-    @ValueMapValue
-    private Boolean expanded;
+	@ValueMapValue
+	@Named("and")
+	@Default(booleanValues = false)
+	private boolean and;
 
-    @ValueMapValue(name = PropertyPredicateImpl.PN_TYPE)
-    private String typeString;
+	@ValueMapValue
+	private String source;
 
-    @ValueMapValue
-    @Named("and")
-    @Default(booleanValues = false)
-    private boolean and;
+	@ValueMapValue
+	private String jsonSource;
 
-    @PostConstruct
-    protected void init() {
-        initPredicate(request, coreOptions);
-    }
+	@PostConstruct
+	protected void init() {
+		initPredicate(request, coreOptions);
+	}
 
-    /* Options - Core Component Delegates */
+	/* Options - Core Component Delegates */
 
-    public List<OptionItem> getItems() {
-        final ValueMap initialValues = getInitialValues();
-        final List<OptionItem> processedOptionItems = new ArrayList<>();
-        final boolean useDefaultSelected = !isParameterizedSearchRequest();
+	public List<OptionItem> getItems() {
+		final ValueMap initialValues = getInitialValues();
+		final List<OptionItem> processedOptionItems = new ArrayList<>();
+		final boolean useDefaultSelected = !isParameterizedSearchRequest();
 
-        coreOptions.getItems().stream()
-                .forEach(optionItem -> {
-                    if (PredicateUtil.isOptionInInitialValues(optionItem, initialValues)) {
-                        processedOptionItems.add(new SelectedOptionItem(optionItem));
-                    } else if (useDefaultSelected) {
-                        processedOptionItems.add(optionItem);
-                    } else {
-                        processedOptionItems.add(new UnselectedOptionItem(optionItem));
-                    }
-                });
+		if (source.equals("json")){
+			List<JsonOption> jsonOptionItems = getJsonItems();
+			for (JsonOption jsonOption : jsonOptionItems) {
+				processedOptionItems.add(new JsonOptionItem(jsonOption.text, jsonOption.value, PredicateUtil.isOptionInInitialValues(jsonOption.value, initialValues)));
+			}
+		} else{
+			coreOptions.getItems().stream()
+			.forEach(optionItem -> {
+				if (PredicateUtil.isOptionInInitialValues(optionItem, initialValues)) {
+					processedOptionItems.add(new SelectedOptionItem(optionItem));
+				} else if (useDefaultSelected) {
+					processedOptionItems.add(optionItem);
+				} else {
+					processedOptionItems.add(new UnselectedOptionItem(optionItem));
+				}
+			});
+		}
+		return processedOptionItems;
+	}
 
-        return processedOptionItems;
-    }
+	public Type getType() {
+		return coreOptions.getType();
+	}
 
-    public Type getType() {
-        return coreOptions.getType();
-    }
+	/* Property Predicate Specific */
 
-    /* Property Predicate Specific */
+	public String getSubType() {
+		//support variation of Checkboxes
+		return typeString;
+	}
 
-    public String getSubType() {
-        //support variation of Checkboxes
-        return typeString;
-    }
+	@Override
+	public String getProperty() {
+		return property;
+	}
 
-    @Override
-    public String getProperty() {
-        return property;
-    }
+	@Override
+	public String getValuesKey() {
+		return PropertyValuesPredicateEvaluator.VALUES;
+	}
 
-    @Override
-    public String getValuesKey() {
-        return PropertyValuesPredicateEvaluator.VALUES;
-    }
+	@Override
+	public boolean hasOperation() {
+		return StringUtils.isNotBlank(getOperation());
+	}
 
-    @Override
-    public boolean hasOperation() {
-        return StringUtils.isNotBlank(getOperation());
-    }
+	@Override
+	public String getOperation() {
+		return operation;
+	}
 
-    @Override
-    public String getOperation() {
-        return operation;
-    }
+	public boolean hasAnd() {
+		return and;
+	}
 
-    public boolean hasAnd() {
-        return and;
-    }
+	public Boolean getAnd() {
+		return and;
+	}
 
-    public Boolean getAnd() {
-        return and;
-    }
+	@Override
+	public String getName() {
+		return PropertyValuesPredicateEvaluator.PREDICATE_NAME;
+	}
 
-    @Override
-    public String getName() {
-        return PropertyValuesPredicateEvaluator.PREDICATE_NAME;
-    }
+	@Override
+	public boolean isReady() {
+		return coreOptions.getItems().size() > 0;
+	}
 
-    @Override
-    public boolean isReady() {
-        return coreOptions.getItems().size() > 0;
-    }
+	@Override
+	public String getInitialValue() {
+		if (valueFromRequest == null) {
+			valueFromRequest = PredicateUtil.getInitialValue(request, this, PropertyValuesPredicateEvaluator.VALUES);
+		}
 
-    @Override
-    public String getInitialValue() {
-        if (valueFromRequest == null) {
-            valueFromRequest = PredicateUtil.getInitialValue(request, this, PropertyValuesPredicateEvaluator.VALUES);
-        }
+		return valueFromRequest;
+	}
 
-        return valueFromRequest;
-    }
+	@Override
+	public ValueMap getInitialValues() {
+		if (valuesFromRequest == null) {
+			valuesFromRequest = PredicateUtil.getInitialValues(request, this, PropertyValuesPredicateEvaluator.VALUES);
+		}
 
-    @Override
-    public ValueMap getInitialValues() {
-        if (valuesFromRequest == null) {
-            valuesFromRequest = PredicateUtil.getInitialValues(request, this, PropertyValuesPredicateEvaluator.VALUES);
-        }
+		return valuesFromRequest;
+	}
 
-        return valuesFromRequest;
-    }
+	@Nonnull
+	@Override
+	public String getExportedType() {
+		return RESOURCE_TYPE;
+	}
 
-    @Nonnull
-    @Override
-    public String getExportedType() {
-        return RESOURCE_TYPE;
-    }
+	private List<JsonOption> getJsonItems(){
+		List<JsonOption> options = new ArrayList<>();
+		// Get option from json type asset and inject via jsonSource filepath
+		@Nullable
+		Resource resource = request.getResourceResolver().getResource(jsonSource);
+		String resourceType = resource.getResourceType();
+		if(resourceType != null && resourceType.equalsIgnoreCase(DAM_RESOURCE_TYPE)) {
+			Asset jsonAsset = DamUtil.resolveToAsset(request.getResourceResolver().getResource(jsonSource));
+
+			try(InputStream stream = jsonAsset.getOriginal().adaptTo(InputStream.class);
+					BufferedReader reader = new BufferedReader(
+							new InputStreamReader(stream, StandardCharsets.UTF_8))) {
+
+				Gson gson = new Gson();
+				JsonObject jsonObject = gson.fromJson(reader, JsonObject.class);
+				if (jsonObject.isJsonObject()){
+					JsonElement optionsJson = jsonObject.get("options");
+					options = gson.fromJson(optionsJson, new TypeToken<List<JsonOption>>() {}.getType());
+					return options;
+				}
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+			// End of reading options from Json asset
+		}else {
+			// Start of reading options from generic list  /etc/acs-commons/lists/audience/jcr:content/list
+			Iterable<Resource> dropdownListItem = resource.getChildren();
+			for (Resource optionResource : dropdownListItem) {
+				ValueMap valueMap = optionResource.getValueMap();
+				options.add(new JsonOption(valueMap.get("jcr:title",String.class), valueMap.get("value",String.class)));
+			}
+			return options;
+		}
+		return null;
+	}
+
+	protected class JsonOption {
+		private String text;
+		private String value;
+
+		public JsonOption(String text, String value) {
+			this.text = text;
+			this.value = value;
+		}
+
+
+		public String getText() {
+			return text;
+		}
+
+
+		public String getValue() {
+			return value;
+		}
+
+	}
 }

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/PropertyPredicateImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/PropertyPredicateImpl.java
@@ -19,31 +19,6 @@
 
 package com.adobe.aem.commons.assetshare.components.predicates.impl;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import javax.annotation.PostConstruct;
-import javax.inject.Named;
-
-import org.apache.commons.lang3.StringUtils;
-import org.apache.sling.api.SlingHttpServletRequest;
-import org.apache.sling.api.resource.Resource;
-import org.apache.sling.api.resource.ValueMap;
-import org.apache.sling.models.annotations.Default;
-import org.apache.sling.models.annotations.DefaultInjectionStrategy;
-import org.apache.sling.models.annotations.Exporter;
-import org.apache.sling.models.annotations.Model;
-import org.apache.sling.models.annotations.Required;
-import org.apache.sling.models.annotations.injectorspecific.Self;
-import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
-
 import com.adobe.aem.commons.assetshare.components.predicates.AbstractPredicate;
 import com.adobe.aem.commons.assetshare.components.predicates.PropertyPredicate;
 import com.adobe.aem.commons.assetshare.components.predicates.impl.options.JsonOptionItem;
@@ -62,62 +37,89 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
 
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.models.annotations.Default;
+import org.apache.sling.models.annotations.DefaultInjectionStrategy;
+import org.apache.sling.models.annotations.Exporter;
+import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.Required;
+import org.apache.sling.models.annotations.injectorspecific.Self;
+import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.PostConstruct;
+import javax.inject.Named;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
 @Model(
-		adaptables = {SlingHttpServletRequest.class},
-		adapters = {PropertyPredicate.class, ComponentExporter.class},
-		resourceType = {PropertyPredicateImpl.RESOURCE_TYPE},
-		defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL
-		)
+        adaptables = {SlingHttpServletRequest.class},
+        adapters = {PropertyPredicate.class, ComponentExporter.class},
+        resourceType = {PropertyPredicateImpl.RESOURCE_TYPE},
+        defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL
+)
 @Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME, extensions = ExporterConstants.SLING_MODEL_EXTENSION)
 public class PropertyPredicateImpl extends AbstractPredicate implements PropertyPredicate, Options {
 
-	protected static final String RESOURCE_TYPE = "asset-share-commons/components/search/property";
-	protected static final String PN_TYPE = "type";
-	protected String valueFromRequest = null;
-	protected ValueMap valuesFromRequest = null;
-	protected static final String DAM_RESOURCE_TYPE = "dam:Asset";
-	@Self
-	@Required
-	private SlingHttpServletRequest request;
+    protected static final String RESOURCE_TYPE = "asset-share-commons/components/search/property";
+    protected static final String PN_TYPE = "type";
 
-	@Self
-	@Required
-	private Options coreOptions;
+    protected String valueFromRequest = null;
+    protected ValueMap valuesFromRequest = null;
+    protected static final String DAM_RESOURCE_TYPE = "dam:Asset";
+    
+    @Self
+    @Required
+    private SlingHttpServletRequest request;
 
-	@ValueMapValue
-	private String label;
+    @Self
+    @Required
+    private Options coreOptions;
 
-	@ValueMapValue
-	private String property;
+    @ValueMapValue
+    private String label;
 
-	@ValueMapValue
-	private String operation;
+    @ValueMapValue
+    private String property;
 
-	@ValueMapValue
-	private Boolean expanded;
+    @ValueMapValue
+    private String operation;
 
-	@ValueMapValue(name = PropertyPredicateImpl.PN_TYPE)
-	private String typeString;
+    @ValueMapValue
+    private Boolean expanded;
 
-	@ValueMapValue
-	@Named("and")
-	@Default(booleanValues = false)
-	private boolean and;
+    @ValueMapValue(name = PropertyPredicateImpl.PN_TYPE)
+    private String typeString;
 
-	@ValueMapValue
+    @ValueMapValue
+    @Named("and")
+    @Default(booleanValues = false)
+    private boolean and;
+
+    @ValueMapValue
 	private String source;
 
 	@ValueMapValue
 	private String jsonSource;
+	
+    @PostConstruct
+    protected void init() {
+        initPredicate(request, coreOptions);
+    }
 
-	@PostConstruct
-	protected void init() {
-		initPredicate(request, coreOptions);
-	}
+    /* Options - Core Component Delegates */
 
-	/* Options - Core Component Delegates */
-
-	public List<OptionItem> getItems() {
+    public List<OptionItem> getItems() {
 		final ValueMap initialValues = getInitialValues();
 		final List<OptionItem> processedOptionItems = new ArrayList<>();
 		final boolean useDefaultSelected = !isParameterizedSearchRequest();
@@ -142,80 +144,80 @@ public class PropertyPredicateImpl extends AbstractPredicate implements Property
 		return processedOptionItems;
 	}
 
-	public Type getType() {
-		return coreOptions.getType();
-	}
+    public Type getType() {
+        return coreOptions.getType();
+    }
 
-	/* Property Predicate Specific */
+    /* Property Predicate Specific */
 
-	public String getSubType() {
-		//support variation of Checkboxes
-		return typeString;
-	}
+    public String getSubType() {
+        //support variation of Checkboxes
+        return typeString;
+    }
 
-	@Override
-	public String getProperty() {
-		return property;
-	}
+    @Override
+    public String getProperty() {
+        return property;
+    }
 
-	@Override
-	public String getValuesKey() {
-		return PropertyValuesPredicateEvaluator.VALUES;
-	}
+    @Override
+    public String getValuesKey() {
+        return PropertyValuesPredicateEvaluator.VALUES;
+    }
 
-	@Override
-	public boolean hasOperation() {
-		return StringUtils.isNotBlank(getOperation());
-	}
+    @Override
+    public boolean hasOperation() {
+        return StringUtils.isNotBlank(getOperation());
+    }
 
-	@Override
-	public String getOperation() {
-		return operation;
-	}
+    @Override
+    public String getOperation() {
+        return operation;
+    }
 
-	public boolean hasAnd() {
-		return and;
-	}
+    public boolean hasAnd() {
+        return and;
+    }
 
-	public Boolean getAnd() {
-		return and;
-	}
+    public Boolean getAnd() {
+        return and;
+    }
 
-	@Override
-	public String getName() {
-		return PropertyValuesPredicateEvaluator.PREDICATE_NAME;
-	}
+    @Override
+    public String getName() {
+        return PropertyValuesPredicateEvaluator.PREDICATE_NAME;
+    }
 
-	@Override
-	public boolean isReady() {
-		return coreOptions.getItems().size() > 0;
-	}
+    @Override
+    public boolean isReady() {
+        return coreOptions.getItems().size() > 0;
+    }
 
-	@Override
-	public String getInitialValue() {
-		if (valueFromRequest == null) {
-			valueFromRequest = PredicateUtil.getInitialValue(request, this, PropertyValuesPredicateEvaluator.VALUES);
-		}
+    @Override
+    public String getInitialValue() {
+        if (valueFromRequest == null) {
+            valueFromRequest = PredicateUtil.getInitialValue(request, this, PropertyValuesPredicateEvaluator.VALUES);
+        }
 
-		return valueFromRequest;
-	}
+        return valueFromRequest;
+    }
 
-	@Override
-	public ValueMap getInitialValues() {
-		if (valuesFromRequest == null) {
-			valuesFromRequest = PredicateUtil.getInitialValues(request, this, PropertyValuesPredicateEvaluator.VALUES);
-		}
+    @Override
+    public ValueMap getInitialValues() {
+        if (valuesFromRequest == null) {
+            valuesFromRequest = PredicateUtil.getInitialValues(request, this, PropertyValuesPredicateEvaluator.VALUES);
+        }
 
-		return valuesFromRequest;
-	}
+        return valuesFromRequest;
+    }
 
-	@Nonnull
-	@Override
-	public String getExportedType() {
-		return RESOURCE_TYPE;
-	}
-
-	private List<JsonOption> getJsonItems(){
+    @Nonnull
+    @Override
+    public String getExportedType() {
+        return RESOURCE_TYPE;
+    }
+    
+    private List<JsonOption> getJsonItems(){
 		List<JsonOption> options = new ArrayList<>();
 		// Get option from json type asset and inject via jsonSource filepath
 		@Nullable

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/options/JsonOptionItem.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/options/JsonOptionItem.java
@@ -1,0 +1,33 @@
+package com.adobe.aem.commons.assetshare.components.predicates.impl.options;
+
+import com.adobe.cq.wcm.core.components.models.form.OptionItem;
+
+public class JsonOptionItem implements OptionItem {
+	private String text;
+    private String value;
+    private boolean selected;
+    
+    
+    public JsonOptionItem(String text, String value, boolean selected) {
+        this.text = text;
+        this.value = value;
+        this.selected = selected;
+    }
+
+
+	public String getText() {
+		return text;
+	}
+
+
+	public String getValue() {
+		return value;
+	}
+
+
+	public boolean isSelected() {
+		return selected;
+	}
+
+    
+}

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/util/JsonResolver.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/util/JsonResolver.java
@@ -1,3 +1,22 @@
+/*
+ * Asset Share Commons
+ *
+ * Copyright (C) 2023 Adobe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package com.adobe.aem.commons.assetshare.util;
 
 import com.google.gson.JsonElement;
@@ -5,8 +24,16 @@ import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.osgi.annotation.versioning.ProviderType;
 
-
-
+/**
+ * This OSGi service provides a method to resolve a JSON object from a path. The path can be:
+ *
+ * - The full JCR path to a nt:file/nt:resource/oak:Resource with mime type of application/json
+ * - The full JCR path to a dam:Asset
+ * - An absolute HTTP/HTTPS URL to a resource that returns a JSON file.
+ * - An internal resource path that is resolved via an internal Sling request.
+ * - The absolute path to an ACS AEM Commons Generic List page; this will return the list items under a "options" property in the returned JSON object. ("{ options: [ { ... }, { ... } ] }")
+ * - Or null if JSON cannot be resolved for any reason.
+ */
 @ProviderType
 public interface JsonResolver {
     /**

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/util/JsonResolver.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/util/JsonResolver.java
@@ -1,6 +1,6 @@
 package com.adobe.aem.commons.assetshare.util;
 
-import com.google.gson.JsonObject;
+import com.google.gson.JsonElement;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.osgi.annotation.versioning.ProviderType;
@@ -17,5 +17,5 @@ public interface JsonResolver {
      * @param path     the path to resolve, this can be a internal JCR Path to a nt:file/nt:resource, dam:Asset, and internal resource that is requested via an internal sling request, or an external url (starting with http:// or https://).
      * @return the JSON object or null if the path could not be resolved.
      */
-    JsonObject resolveJson(SlingHttpServletRequest request, SlingHttpServletResponse response, String path);
+    JsonElement resolveJson(SlingHttpServletRequest request, SlingHttpServletResponse response, String path);
 }

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/util/impl/JsonResolverImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/util/impl/JsonResolverImpl.java
@@ -1,10 +1,7 @@
 package com.adobe.aem.commons.assetshare.util.impl;
 
 import com.adobe.acs.commons.util.BufferedServletOutput;
-import com.adobe.acs.commons.util.BufferedSlingHttpServletResponse;
-import com.adobe.acs.commons.util.PathInfoUtil;
 import com.adobe.aem.commons.assetshare.util.JsonResolver;
-import com.adobe.aem.commons.assetshare.util.impl.requests.ExtensionOverrideRequestWrapper;
 import com.adobe.aem.commons.assetshare.util.impl.requests.IncludableRequestWrapper;
 import com.adobe.aem.commons.assetshare.util.impl.responses.IncludableResponseWrapper;
 import com.day.cq.commons.PathInfo;
@@ -16,6 +13,7 @@ import com.day.cq.wcm.api.WCMMode;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
@@ -31,7 +29,6 @@ import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.util.StringJoiner;
 
 import static org.apache.jackrabbit.JcrConstants.NT_FILE;
 import static org.apache.jackrabbit.JcrConstants.NT_RESOURCE;
@@ -61,7 +58,10 @@ public class JsonResolverImpl implements JsonResolver {
                 if (page != null) {
                     path = page.getPath() + "/jcr:content.list.json";
                 }
-                result = getJsonAsInternalRequest(request, response, path);
+                JsonElement jsonArray = getJsonAsInternalRequest(request, response, path);
+                JsonObject jsonObject = new JsonObject();
+                jsonObject.add("options", jsonArray);
+                return jsonObject;
             } else {
                 result = getJsonAsInternalRequest(request, response, path);
             }
@@ -151,25 +151,5 @@ public class JsonResolverImpl implements JsonResolver {
         BufferedReader reader = new BufferedReader(
                 new InputStreamReader(inputStream, StandardCharsets.UTF_8));
         return new Gson().fromJson(reader, JsonElement.class);
-
-        /*
-        StringJoiner stringJoiner = new StringJoiner("\n");
-        String line;
-        try {
-            while ((line = reader.readLine()) != null) {
-                line = StringUtils.trimToEmpty(line);
-                if (StringUtils.startsWith(line, "<") || StringUtils.isBlank(line)) {
-                    // Skip
-                } else {
-                    stringJoiner.add(line);
-                }
-            }
-        } catch (IOException e) {
-            log.warn("Unable to read JSON from input stream", e);
-            return new JsonArray();
-        }
-
-         */
-
     }
 }

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/util/impl/JsonResolverImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/util/impl/JsonResolverImpl.java
@@ -98,7 +98,7 @@ public class JsonResolverImpl implements JsonResolver {
         options.setReplaceSuffix("");
 
         request.getRequestDispatcher(pathInfo.getResourcePath(), options)
-                .include(new ExtensionOverrideRequestWrapper(request, extension), wrappedResponse);
+                .forward(new ExtensionOverrideRequestWrapper(request, extension), wrappedResponse);
 
         byte[] bytes = null;
         if (wrappedResponse.getBufferedServletOutput().getWriteMethod() == BufferedServletOutput.ResponseWriteMethod.WRITER) {

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/util/impl/JsonResolverImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/util/impl/JsonResolverImpl.java
@@ -46,6 +46,10 @@ public class JsonResolverImpl implements JsonResolver {
                 result = getJsonStringFromDamAsset(resource);
             } else if (resource == null && StringUtils.startsWithAny(path, "http://", "https://")) {
                 result = getJsonFromExternalUrl(path);
+            } else if (resource != null && StringUtils.startsWithAny(path, "/etc/acs-commons/lists/")) {
+                path = StringUtils.substringBefore(path, ".");
+                path = path + ".list.json";
+                result = getJsonAsInternalRequest(request, response, path);
             } else {
                 result = getJsonAsInternalRequest(request, response, path);
             }

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/util/impl/JsonResolverImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/util/impl/JsonResolverImpl.java
@@ -1,3 +1,22 @@
+/*
+ * Asset Share Commons
+ *
+ * Copyright (C) 2023 Adobe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package com.adobe.aem.commons.assetshare.util.impl;
 
 import com.adobe.acs.commons.util.BufferedServletOutput;
@@ -11,7 +30,6 @@ import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.PageManager;
 import com.day.cq.wcm.api.WCMMode;
 import com.google.gson.Gson;
-import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import org.apache.commons.lang3.StringUtils;
@@ -58,6 +76,7 @@ public class JsonResolverImpl implements JsonResolver {
                 if (page != null) {
                     path = page.getPath() + "/jcr:content.list.json";
                 }
+                // Add the Generic List options to a JSON Object under an options key.
                 JsonElement jsonArray = getJsonAsInternalRequest(request, response, path);
                 JsonObject jsonObject = new JsonObject();
                 jsonObject.add("options", jsonArray);

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/util/impl/requests/IncludableRequestWrapper.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/util/impl/requests/IncludableRequestWrapper.java
@@ -1,0 +1,62 @@
+package com.adobe.aem.commons.assetshare.util.impl.requests;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+
+public class IncludableRequestWrapper extends ExtensionOverrideRequestWrapper{
+    private HashMap<String, Object> attributes = new HashMap<>();
+    private String contentType;
+
+    /**
+     * @param wrappedRequest the request to wrap;
+     * @param extension      the extension to force. Set to null for no extension;
+     */
+    public IncludableRequestWrapper(SlingHttpServletRequest wrappedRequest, String extension) {
+        super(wrappedRequest, extension);
+        contentType = wrappedRequest.getContentType();
+    }
+
+
+    public void setContentType(String contentType) {
+        this.contentType = contentType;
+    }
+
+    @Override
+    public String getContentType() {
+        return contentType;
+    }
+
+    @Override
+    public void setAttribute(String name, Object o) {
+        attributes.put(name, o);
+    }
+
+    @Override
+    public Object getAttribute(String name) {
+        if (attributes.containsKey(name)) {
+            return attributes.get(name);
+        }
+        return super.getAttribute(name);
+    }
+
+    @Override
+    public void removeAttribute(String name) {
+        if (attributes.containsKey(name)) {
+            attributes.remove(name);
+            return;
+        }
+        super.removeAttribute(name);
+    }
+
+    @Override
+    public Enumeration<String> getAttributeNames() {
+        List<String> attributeNames = Collections.list(super.getAttributeNames());
+        attributeNames.addAll(attributes.keySet());
+
+        return Collections.enumeration(attributeNames);
+    }
+}

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/util/impl/requests/IncludableRequestWrapper.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/util/impl/requests/IncludableRequestWrapper.java
@@ -1,3 +1,22 @@
+/*
+ * Asset Share Commons
+ *
+ * Copyright (C) 2023 Adobe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package com.adobe.aem.commons.assetshare.util.impl.requests;
 
 import org.apache.sling.api.SlingHttpServletRequest;

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/util/impl/responses/IncludableResponseWrapper.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/util/impl/responses/IncludableResponseWrapper.java
@@ -1,0 +1,23 @@
+package com.adobe.aem.commons.assetshare.util.impl.responses;
+
+import com.adobe.acs.commons.util.BufferedSlingHttpServletResponse;
+import org.apache.sling.api.SlingHttpServletResponse;
+
+public class IncludableResponseWrapper extends BufferedSlingHttpServletResponse {
+    private String contentType;
+
+    public IncludableResponseWrapper(SlingHttpServletResponse wrappedResponse) {
+        super(wrappedResponse);
+        super.getBufferedServletOutput().setFlushBufferOnClose(true);
+    }
+
+    @Override
+    public void setContentType(String type) {
+        contentType = type;
+    }
+
+    @Override
+    public String getContentType() {
+        return contentType;
+    }
+}

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/util/impl/responses/IncludableResponseWrapper.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/util/impl/responses/IncludableResponseWrapper.java
@@ -1,3 +1,22 @@
+/*
+ * Asset Share Commons
+ *
+ * Copyright (C) 2023 Adobe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package com.adobe.aem.commons.assetshare.util.impl.responses;
 
 import com.adobe.acs.commons.util.BufferedSlingHttpServletResponse;

--- a/core/src/test/java/com/adobe/aem/commons/assetshare/components/predicates/impl/PropertyPredicateImplTest.java
+++ b/core/src/test/java/com/adobe/aem/commons/assetshare/components/predicates/impl/PropertyPredicateImplTest.java
@@ -2,6 +2,8 @@ package com.adobe.aem.commons.assetshare.components.predicates.impl;
 
 import com.adobe.cq.wcm.core.components.models.form.OptionItem;
 import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import org.junit.Before;
 import org.junit.Test;
@@ -24,9 +26,9 @@ public class PropertyPredicateImplTest {
 
         Gson gson = new Gson();
 
-        JsonObject jsonObject = gson.fromJson(json, JsonObject.class);
+        JsonElement jsonElement = gson.fromJson(json, JsonObject.class);
 
-        List<OptionItem> result = propertyPredicate.getOptionItemsFromJson(jsonObject);
+        List<OptionItem> result = propertyPredicate.getOptionItemsFromJson(jsonElement);
 
         assertNotNull(result);
         assertEquals(2, result.size());
@@ -40,13 +42,13 @@ public class PropertyPredicateImplTest {
     public void getKeyValuePairsFromJson_jcrTitleValue() {
         PropertyPredicateImpl propertyPredicate = new PropertyPredicateImpl();
 
-        String json = "{ \"options\": [ { \"jcr:title\": \"the text 1\", \"value\": \"the value 1\" }, { \"jcr:title\": \"the text 2\", \"value\": \"the value 2\" } ] }";
+        String json = "[ { \"text\": \"the text 1\", \"value\": \"the value 1\" }, { \"text\": \"the text 2\", \"value\": \"the value 2\" } ]";
 
         Gson gson = new Gson();
 
-        JsonObject jsonObject = gson.fromJson(json, JsonObject.class);
+        JsonElement jsonElement = gson.fromJson(json, JsonArray.class);
 
-        List<OptionItem> result = propertyPredicate.getOptionItemsFromJson(jsonObject);
+        List<OptionItem> result = propertyPredicate.getOptionItemsFromJson(jsonElement);
 
         assertNotNull(result);
         assertEquals(2, result.size());

--- a/core/src/test/java/com/adobe/aem/commons/assetshare/components/predicates/impl/PropertyPredicateImplTest.java
+++ b/core/src/test/java/com/adobe/aem/commons/assetshare/components/predicates/impl/PropertyPredicateImplTest.java
@@ -1,0 +1,58 @@
+package com.adobe.aem.commons.assetshare.components.predicates.impl;
+
+import com.adobe.cq.wcm.core.components.models.form.OptionItem;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class PropertyPredicateImplTest {
+
+    @Before
+    public void setUp() throws Exception {
+    }
+
+    @Test
+    public void getKeyValuePairsFromJson_textValue() {
+        PropertyPredicateImpl propertyPredicate = new PropertyPredicateImpl();
+
+        String json = "{ \"options\": [ { \"text\": \"the text 1\", \"value\": \"the value 1\" }, { \"text\": \"the text 2\", \"value\": \"the value 2\" } ] }";
+
+        Gson gson = new Gson();
+
+        JsonObject jsonObject = gson.fromJson(json, JsonObject.class);
+
+        List<OptionItem> result = propertyPredicate.getOptionItemsFromJson(jsonObject);
+
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertEquals("the text 1", result.get(0).getText());
+        assertEquals("the value 1", result.get(0).getValue());
+        assertEquals("the text 2", result.get(1).getText());
+        assertEquals("the value 2", result.get(1).getValue());
+    }
+
+    @Test
+    public void getKeyValuePairsFromJson_jcrTitleValue() {
+        PropertyPredicateImpl propertyPredicate = new PropertyPredicateImpl();
+
+        String json = "{ \"options\": [ { \"jcr:title\": \"the text 1\", \"value\": \"the value 1\" }, { \"jcr:title\": \"the text 2\", \"value\": \"the value 2\" } ] }";
+
+        Gson gson = new Gson();
+
+        JsonObject jsonObject = gson.fromJson(json, JsonObject.class);
+
+        List<OptionItem> result = propertyPredicate.getOptionItemsFromJson(jsonObject);
+
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertEquals("the text 1", result.get(0).getText());
+        assertEquals("the value 1", result.get(0).getValue());
+        assertEquals("the text 2", result.get(1).getText());
+        assertEquals("the value 2", result.get(1).getValue());
+    }
+}

--- a/core/src/test/java/com/adobe/aem/commons/assetshare/util/impl/JsonResolverImplTest.java
+++ b/core/src/test/java/com/adobe/aem/commons/assetshare/util/impl/JsonResolverImplTest.java
@@ -1,3 +1,22 @@
+/*
+ * Asset Share Commons
+ *
+ * Copyright (C) 2023 Adobe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package com.adobe.aem.commons.assetshare.util.impl;
 
 import com.adobe.aem.commons.assetshare.util.JsonResolver;

--- a/core/src/test/java/com/adobe/aem/commons/assetshare/util/impl/JsonResolverImplTest.java
+++ b/core/src/test/java/com/adobe/aem/commons/assetshare/util/impl/JsonResolverImplTest.java
@@ -1,6 +1,7 @@
 package com.adobe.aem.commons.assetshare.util.impl;
 
 import com.adobe.aem.commons.assetshare.util.JsonResolver;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import io.wcm.testing.mock.aem.junit.AemContext;
 import org.junit.Before;
@@ -35,20 +36,20 @@ public class JsonResolverImplTest {
     public void resolveDamAsset() {
         JsonResolver jsonResolver = ctx.getService(JsonResolver.class);
 
-        JsonObject actual = jsonResolver.resolveJson(ctx.request(), ctx.response(), "/content/dam/test-dam-asset.json");
+        JsonElement actual = jsonResolver.resolveJson(ctx.request(), ctx.response(), "/content/dam/test-dam-asset.json");
 
         assertNotNull(actual);
-        assertEquals("dam asset", actual.get("test").getAsString());
+        assertEquals("dam asset", actual.getAsJsonObject().get("test").getAsString());
     }
 
     @Test
     public void resolveExternalInclude() {
         JsonResolver jsonResolver = ctx.getService(JsonResolver.class);
 
-        JsonObject actual = jsonResolver.resolveJson(ctx.request(), ctx.response(), "https://opensource.adobe.com/asset-share-commons/tests/example.json");
+        JsonElement actual = jsonResolver.resolveJson(ctx.request(), ctx.response(), "https://opensource.adobe.com/asset-share-commons/tests/example.json");
 
         assertNotNull(actual);
-        assertEquals("remote test json file.", actual.get("test").getAsString());
+        assertEquals("remote test json file.", actual.getAsJsonObject().get("test").getAsString());
     }
 
 
@@ -57,10 +58,10 @@ public class JsonResolverImplTest {
         // This test requires too much mocking to be worth it.
         JsonResolver jsonResolver = ctx.getService(JsonResolver.class);
 
-        JsonObject actual = jsonResolver.resolveJson(ctx.request(), ctx.response(), "/content/test-internal-include.json");
+        JsonElement actual = jsonResolver.resolveJson(ctx.request(), ctx.response(), "/content/test-internal-include.json");
 
         assertNotNull(actual);
-        assertEquals("internal include", actual.get("test").getAsString());
+        assertEquals("internal include", actual.getAsJsonObject().get("test").getAsString());
     }
 }
 

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/metadata/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/metadata/_cq_dialog/.content.xml
@@ -290,7 +290,7 @@
                                                             fieldDescription="A JSON file having an options array with text and value fields."
                                                             fieldLabel="JSON"
                                                             name="./jsonSource"
-                                                            rootPath="/content"
+                                                            rootPath="/"
                                                             required="{Boolean}true">
                                                     </json>
                                                 </items>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/metadata/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/metadata/_cq_dialog/.content.xml
@@ -290,7 +290,7 @@
                                                             fieldDescription="A JSON file having an options array with text and value fields."
                                                             fieldLabel="JSON"
                                                             name="./jsonSource"
-                                                            rootPath="/content/dam"
+                                                            rootPath="/content"
                                                             required="{Boolean}true">
                                                     </json>
                                                 </items>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/metadata/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/metadata/_cq_dialog/.content.xml
@@ -279,7 +279,7 @@
                                                     jcr:primaryType="nt:unstructured"
                                                     sling:resourceType="granite/ui/components/coral/foundation/heading"
                                                     level="{Long}4"
-                                                    text="JSON lookup file"/>
+                                                    text="JSON lookup"/>
                                             <well
                                                     jcr:primaryType="nt:unstructured"
                                                     sling:resourceType="granite/ui/components/coral/foundation/well">
@@ -287,7 +287,7 @@
                                                     <json
                                                             jcr:primaryType="nt:unstructured"
                                                             sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
-                                                            fieldDescription="A JSON file having an options array with text and value fields."
+                                                            fieldDescription="A JSON source containing asset property value to display value mappings."
                                                             fieldLabel="JSON"
                                                             name="./jsonSource"
                                                             rootPath="/"

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/property/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/property/_cq_dialog/.content.xml
@@ -262,7 +262,7 @@
                                                                             sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
                                                                             fieldDescription="A JSON file containing the dropdown options as text and value fields."
                                                                             fieldLabel="JSON Source"
-                                                                            rootPath="/content/dam"
+                                                                            rootPath="/"
                                                                             name="./jsonSource"
                                                                             required="{Boolean}true">
                                                                     </json>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/property/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/property/_cq_dialog/.content.xml
@@ -260,7 +260,7 @@
                                                                     <json
                                                                             jcr:primaryType="nt:unstructured"
                                                                             sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
-                                                                            fieldDescription="A JSON file containing the dropdown options as text and value fields."
+                                                                            fieldDescription="A JSON source containing the filter options."
                                                                             fieldLabel="JSON Source"
                                                                             rootPath="/"
                                                                             name="./jsonSource"

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/property/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/property/_cq_dialog/.content.xml
@@ -168,6 +168,10 @@
                                                                             jcr:primaryType="nt:unstructured"
                                                                             text="Datasource"
                                                                             value="datasource"/>
+                                                                    <json
+                                                                        jcr:primaryType="nt:unstructured"
+                                                                        text="JSON"
+                                                                        value="json"/>
                                                                 </items>
                                                             </source>
                                                             <fromDatasource
@@ -245,6 +249,25 @@
                                                                     </options>
                                                                 </items>
                                                             </fromLocal>
+                                                            <fromJson
+                                                                    granite:class="hide list-option-listfrom-showhide-target foundation-layout-util-vmargin"
+                                                                    jcr:primaryType="nt:unstructured"
+                                                                    sling:resourceType="granite/ui/components/coral/foundation/container">
+                                                                <granite:data
+                                                                        jcr:primaryType="nt:unstructured"
+                                                                        showhidetargetvalue="json"/>
+                                                                <items jcr:primaryType="nt:unstructured">
+                                                                    <json
+                                                                            jcr:primaryType="nt:unstructured"
+                                                                            sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
+                                                                            fieldDescription="A JSON file containing the dropdown options as text and value fields."
+                                                                            fieldLabel="JSON Source"
+                                                                            rootPath="/content/dam"
+                                                                            name="./jsonSource"
+                                                                            required="{Boolean}true">
+                                                                    </json>
+                                                                </items>
+                                                            </fromJson>
                                                         </items>
                                                     </column>
                                                 </items>


### PR DESCRIPTION
## Description

Add ability to source JSON (typically to power Component options) from other things besides dam:Asset files:

1. nt:file/nt:resource/oak:Resource resources
2. dam:Assets
3. ACS AEM Commons generic lists
4. External URLs
5. Internal URLs (ex. /content/some/resource.my-options.json) 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
