### PR TITLE
Fix user info rendering when profile.json isn't available

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-site/js/profile.js
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-site/js/profile.js
@@ -29,7 +29,7 @@ AssetShare.Profile = (function ($, ns, profileStore) {
           PROFILE_EXT        = 'profile.json';
 
     // initally check to see if profile is ready based on local storage
-    if(profileStore.isReady()) {
+    if(profileStore.isReady() && profileStore.getUserProfile()) {
         announceProfileLoaded(profileStore.getUserProfile());
     }
 
@@ -82,6 +82,13 @@ AssetShare.Profile = (function ($, ns, profileStore) {
             announceProfileLoaded(currentUser);
 
         }).fail(function() {
+            if (currentUser) {
+                // update profile in local storage
+                profileStore.setUserProfile(currentUser);
+
+                //announce profile updated
+                announceProfileLoaded(currentUser);
+            }
             console.error('Could not retrieve a user home, extra profile attributes not set.');
         });
     }


### PR DESCRIPTION
Fix user information rendering when profile.json is not found. This is the case for us when we use LDAP login. 

## Description

## Related Issue

https://github.com/adobe/asset-share-commons/issues/1000

## Motivation and Context

see issue

## How Has This Been Tested?

Tested locally

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
