### PR TITLE
Added OSGi configuration for Adobe Embed PDF API client ID

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.adobe.aem.commons</groupId>
         <artifactId>assetshare</artifactId>
-        <version>3.7.3-SNAPSHOT</version>
+        <version>3.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core.cloud/pom.xml
+++ b/core.cloud/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.adobe.aem.commons</groupId>
         <artifactId>assetshare</artifactId>
-        <version>3.7.3-SNAPSHOT</version>
+        <version>3.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.adobe.aem.commons</groupId>
         <artifactId>assetshare</artifactId>
-        <version>3.7.3-SNAPSHOT</version>
+        <version>3.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/util/AdobePdfEmbedApi.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/util/AdobePdfEmbedApi.java
@@ -1,7 +1,7 @@
 /*
  * Asset Share Commons
  *
- * Copyright (C) 2017 Adobe
+ * Copyright (C) 2024 Adobe
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,15 @@
  *
  */
 
-@Version("1.16.0")
 package com.adobe.aem.commons.assetshare.util;
 
-import org.osgi.annotation.versioning.Version;
+import org.osgi.annotation.versioning.ProviderType;
 
+@ProviderType
+public interface AdobePdfEmbedApi {
+
+    /**
+     * @return the Adobe PDF Embed API Client ID.
+     */
+    String getClientId();
+}

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/util/impl/AdobePdfEmbedApiImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/util/impl/AdobePdfEmbedApiImpl.java
@@ -1,0 +1,68 @@
+/*
+ * Asset Share Commons
+ *
+ * Copyright (C) 2024 Adobe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.adobe.aem.commons.assetshare.util.impl;
+
+import com.adobe.aem.commons.assetshare.util.AdobePdfEmbedApi;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.metatype.annotations.Designate;
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
+import org.osgi.service.metatype.annotations.Option;
+
+/**
+ * Allows for Git-based managed Adobe PDF Embed API Client ID used for the Asset Share Commons PDF details.
+ *
+ * https://acrobatservices.adobe.com/dc-integration-creation-app-cdn/main.html?api=pdf-embed-api
+ */
+@Component(
+        configurationPolicy = ConfigurationPolicy.REQUIRE
+)
+@Designate(ocd = AdobePdfEmbedApiImpl.Config.class)
+public class AdobePdfEmbedApiImpl implements AdobePdfEmbedApi {
+    private Config cfg;
+
+    @Override
+    public String getClientId() {
+        return cfg.client_id();
+    }
+
+    @ObjectClassDefinition(
+            name = "Asset Share Commons - Adobe PDF Embed API Configuration",
+            description = "Configuration for the Adobe PDF Embed API. Each domain requires a unique Client ID."
+    )
+    @interface Config {
+        @AttributeDefinition(
+                name = "Adobe PDF Embed API Client ID",
+                description = "Get free Adobe PDF Embed API Client ID from: https://acrobatservices.adobe.com/dc-integration-creation-app-cdn/main.html?api=pdf-embed-api"
+        )
+        String client_id();
+    }
+
+    @Activate
+    @Modified
+    protected void activate(Config cfg) {
+        this.cfg = cfg;
+    }
+
+
+}

--- a/dispatcher/pom.xml
+++ b/dispatcher/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.adobe.aem.commons</groupId>
         <artifactId>assetshare</artifactId>
-        <version>3.7.3-SNAPSHOT</version>
+        <version>3.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <groupId>com.adobe.aem.commons</groupId>
     <artifactId>assetshare</artifactId>
     <packaging>pom</packaging>
-    <version>3.7.3-SNAPSHOT</version>
+    <version>3.8.0-SNAPSHOT</version>
 
     <name>Asset Share Commons - Reactor Project</name>
     <description>asset-share-commons</description>

--- a/ui.apps.structure/pom.xml
+++ b/ui.apps.structure/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.adobe.aem.commons</groupId>
         <artifactId>assetshare</artifactId>
-        <version>3.7.3-SNAPSHOT</version>
+        <version>3.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ui.apps/pom.xml
+++ b/ui.apps/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.adobe.aem.commons</groupId>
         <artifactId>assetshare</artifactId>
-        <version>3.7.3-SNAPSHOT</version>
+        <version>3.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/pdf/_cq_design_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/pdf/_cq_design_dialog/.content.xml
@@ -30,7 +30,7 @@
                                             jcr:primaryType="nt:unstructured"
                                             sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                             emptyText="Enter your Adobe Document Cloud client ID."
-                                            fieldDescription="Enter the client ID for your Adobe Document Cloud account registered with your Adobe Acrobat Viewer."
+                                            fieldDescription="Enter the client ID for your Adobe Document Cloud account registered with your Adobe Acrobat Viewer. This supersedes the any client ID defined in the Adobe PDF Embed API client ID via OSGi configuration."
                                             fieldLabel="Client ID for AEM Publish domain"
                                             name="./publishClientId"/>
 
@@ -38,7 +38,7 @@
                                             jcr:primaryType="nt:unstructured"
                                             sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                             emptyText="Enter your Adobe Document Cloud client ID."
-                                            fieldDescription="Enter the client ID for your Adobe Document Cloud account registered with your Adobe Acrobat Viewer."
+                                            fieldDescription="Enter the client ID for your Adobe Document Cloud account registered with your Adobe Acrobat Viewer. This supersedes the any client ID defined in the Adobe PDF Embed API client ID via OSGi configuration."
                                             fieldLabel="Client ID for AEM Author domain"
                                             name="./authorClientId"/>
                                 </items>

--- a/ui.config/pom.xml
+++ b/ui.config/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.adobe.aem.commons</groupId>
         <artifactId>assetshare</artifactId>
-        <version>3.7.3-SNAPSHOT</version>
+        <version>3.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ui.content.sample/pom.xml
+++ b/ui.content.sample/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.adobe.aem.commons</groupId>
         <artifactId>assetshare</artifactId>
-        <version>3.7.3-SNAPSHOT</version>
+        <version>3.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ui.content/pom.xml
+++ b/ui.content/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.adobe.aem.commons</groupId>
         <artifactId>assetshare</artifactId>
-        <version>3.7.3-SNAPSHOT</version>
+        <version>3.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ui.frontend.theme.dark/pom.xml
+++ b/ui.frontend.theme.dark/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.adobe.aem.commons</groupId>
         <artifactId>assetshare</artifactId>
-        <version>3.7.3-SNAPSHOT</version>
+        <version>3.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ui.frontend.theme.light/pom.xml
+++ b/ui.frontend.theme.light/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.adobe.aem.commons</groupId>
         <artifactId>assetshare</artifactId>
-        <version>3.7.3-SNAPSHOT</version>
+        <version>3.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Added an OSGi configuration to configure the Adobe Embed PDF API client id. This allows for the client ID to be managed in Git for various tiers (Author vs Publish) and for different environments. This can also use Cloud Manager OSGi environemtn variables.

Any values set in the Design Dialog (Policy) for will supersede the OSGi configuration value.

![2024-01-04 at 10 32 AM](https://github.com/adobe/asset-share-commons/assets/1451868/36504fc6-cf2c-4b52-a71a-f4f7a1528336)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
