### PR TITLE
Fix issue when specifying Generic List as JSON source

### DIFF
--- a/core/src/test/java/com/adobe/aem/commons/assetshare/util/impl/JsonResolverImplTest.java
+++ b/core/src/test/java/com/adobe/aem/commons/assetshare/util/impl/JsonResolverImplTest.java
@@ -37,7 +37,7 @@ public class JsonResolverImplTest {
     @Before
     public void setUp() throws Exception {
         ctx.load().json(getClass().getResourceAsStream("JsonResolverImpl.json"), "/content");
-
+        ctx.load().json(getClass().getResourceAsStream("JsonResolverImpl--generic-list.json"), "/etc/acs-commons/lists");
 
         ctx.load().binaryFile(getClass().getResourceAsStream("JsonResolverImpl__file--damAsset.json"),
                 "/content/dam/test-dam-asset.json/jcr:content/renditions/original");
@@ -81,6 +81,20 @@ public class JsonResolverImplTest {
 
         assertNotNull(actual);
         assertEquals("internal include", actual.getAsJsonObject().get("test").getAsString());
+    }
+
+    @Test
+    public void resolveGenericList() {
+        JsonResolver jsonResolver = ctx.getService(JsonResolver.class);
+
+        JsonElement actual = jsonResolver.resolveJson(ctx.request(), ctx.response(), "/etc/acs-commons/lists/test");
+
+        assertNotNull(actual);
+        assertEquals(2, actual.getAsJsonObject().getAsJsonArray("options").size());
+        assertEquals("Item 1", actual.getAsJsonObject().getAsJsonArray("options").get(0).getAsJsonObject().get("text").getAsString());
+        assertEquals("1", actual.getAsJsonObject().getAsJsonArray("options").get(0).getAsJsonObject().get("value").getAsString());
+        assertEquals("Item 2", actual.getAsJsonObject().getAsJsonArray("options").get(1).getAsJsonObject().get("text").getAsString());
+        assertEquals("2", actual.getAsJsonObject().getAsJsonArray("options").get(1).getAsJsonObject().get("value").getAsString());
     }
 }
 

--- a/core/src/test/resources/com/adobe/aem/commons/assetshare/util/impl/JsonResolverImpl--generic-list.json
+++ b/core/src/test/resources/com/adobe/aem/commons/assetshare/util/impl/JsonResolverImpl--generic-list.json
@@ -1,0 +1,26 @@
+{
+
+        "test": {
+          "jcr:primaryType": "cq:Page",
+          "jcr:title": "Generic list page",
+          "jcr:content": {
+            "jcr:primaryType": "cq:PageContent",
+            "sling:resourceType": "acs-commons/components/utilities/genericlist",
+            "list": {
+              "jcr:primaryType": "nt:unstructured",
+              "item1": {
+                "jcr:primaryType": "nt:unstructured",
+                "jcr:title": "Item 1",
+                "value": "1"
+              },
+              "item2": {
+                "jcr:primaryType": "nt:unstructured",
+                "jcr:title": "Item 2",
+                "value": "2"
+              }
+            }
+          }
+        }
+      }
+
+


### PR DESCRIPTION
The internal include of the generic list is problematic as it can infinite recursion.

This changes the implementation to simply grab the properties off the resources. This is simpler, and more straightforward.

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

+ + Tested on AEM CS SDK. 
Wrote Unit test.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
