### PR TITLE
#117 - Fixed issue with property predicate breaking initial state due…

### DIFF
--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/PropertyPredicateImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/PropertyPredicateImpl.java
@@ -129,21 +129,11 @@ public class PropertyPredicateImpl extends AbstractPredicate implements Property
     public List<OptionItem> getItems() {
         if (items == null) {
             final ValueMap initialValues = getInitialValues();
-            final List<OptionItem> processedOptionItems = new ArrayList<>();
             final boolean useDefaultSelected = !isParameterizedSearchRequest();
 
-            List<OptionItem> optionItems = new ArrayList<>();
+            List<OptionItem> processedOptionItems = new ArrayList<>();
 
-            if (StringUtils.equalsIgnoreCase("json", source)) {
-                JsonElement jsonElement = jsonResolver.resolveJson(request, response, jsonSource);
-                if (jsonElement != null) {
-                    optionItems = getOptionItemsFromJson(jsonElement);
-                }
-            } else {
-                optionItems = coreOptions.getItems();
-            }
-
-            optionItems.stream()
+            getOptionItems().stream()
                     .forEach(optionItem -> {
                         if (PredicateUtil.isOptionInInitialValues(optionItem, initialValues)) {
                             processedOptionItems.add(new SelectedOptionItem(optionItem));
@@ -158,6 +148,20 @@ public class PropertyPredicateImpl extends AbstractPredicate implements Property
         }
 
         return items;
+    }
+
+    private List<OptionItem> getOptionItems() {
+        List<OptionItem> optionItems = new ArrayList<>();
+
+        if (StringUtils.equalsIgnoreCase("json", source)) {
+            JsonElement jsonElement = jsonResolver.resolveJson(request, response, jsonSource);
+            if (jsonElement != null) {
+                optionItems = getOptionItemsFromJson(jsonElement);
+            }
+        } else {
+            optionItems = coreOptions.getItems();
+        }
+        return optionItems;
     }
 
     public Type getType() {
@@ -206,7 +210,8 @@ public class PropertyPredicateImpl extends AbstractPredicate implements Property
 
     @Override
     public boolean isReady() {
-        return getItems().size() > 0;
+        // Do NOT call getItems() the group is not initialized yet.
+        return getOptionItems().size() > 0;
     }
 
     @Override
@@ -288,6 +293,8 @@ public class PropertyPredicateImpl extends AbstractPredicate implements Property
 
         return values;
     }
+
+
 
 
     protected class TextValueJsonOption implements OptionItem {


### PR DESCRIPTION
… cyclic dependency on group id generation

![2024-04-24 at 11 01 AM](https://github.com/adobe/asset-share-commons/assets/1451868/8a1712e8-6d3f-4a89-beeb-95cd721608d3)


<!--- Provide a general summary of your changes in the Title above -->

## Description

Predicate Group ID creation called isReady() which called getItems() which ended up using the wrong groupID since that predicate's groupID hadnt been properly created it.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [X] All new and existing tests passed.
