### PR TITLE
Fixed issue with thumbnails not showing for assets missing dc:format

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -112,6 +112,9 @@
             <id>cloud</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>env.CM_BUILD</name>
+                </property>
             </activation>
             <build>
                 <plugins>

--- a/core.cloud/src/main/java/com/adobe/aem/commons/assetshare/content/renditions/impl/dispatchers/AssetDeliveryRenditionDispatcherImpl.java
+++ b/core.cloud/src/main/java/com/adobe/aem/commons/assetshare/content/renditions/impl/dispatchers/AssetDeliveryRenditionDispatcherImpl.java
@@ -232,7 +232,13 @@ public class AssetDeliveryRenditionDispatcherImpl extends AbstractRenditionDispa
         final String assetFormat = StringUtils.lowerCase(assetModel.getProperties().get(DamConstants.DC_FORMAT, String.class));
 
         // Return true if assetFormat matches any regex in ALLOWED_MIME_TYPES
-        return Arrays.stream(ACCEPTED_MIME_TYPES).anyMatch(regex -> assetFormat.matches(regex));
+        if (StringUtils.isBlank(assetFormat)) {
+            // If the asset format is not set, we can't determine if it's an image or document, so we can't use Asset Delivery
+            return false;
+        } else {
+            // Otherwise, check if the asset format is an image or document
+            return Arrays.stream(ACCEPTED_MIME_TYPES).anyMatch(regex -> assetFormat.matches(regex));
+        }
     }
 
     protected String evaluateExpression(final SlingHttpServletRequest request, String expression) {

--- a/core.cloud/src/test/java/com/adobe/aem/commons/assetshare/content/renditions/impl/dispatchers/AssetDeliveryRenditionDispatcherImplTest.java
+++ b/core.cloud/src/test/java/com/adobe/aem/commons/assetshare/content/renditions/impl/dispatchers/AssetDeliveryRenditionDispatcherImplTest.java
@@ -1,0 +1,89 @@
+package com.adobe.aem.commons.assetshare.content.renditions.impl.dispatchers;
+
+import com.adobe.aem.commons.assetshare.content.AssetModel;
+import com.adobe.aem.commons.assetshare.content.impl.AssetModelImpl;
+import com.adobe.aem.commons.assetshare.content.renditions.AssetRenditionDispatcher;
+import com.adobe.aem.commons.assetshare.content.renditions.impl.AssetRenditionsImpl;
+import com.adobe.aem.commons.assetshare.testing.MockAssetModels;
+import com.adobe.aem.commons.assetshare.testing.RequireAemMock;
+import com.adobe.aem.commons.assetshare.util.ExpressionEvaluator;
+import com.adobe.aem.commons.assetshare.util.RequireAem;
+import com.adobe.aem.commons.assetshare.util.impl.ExpressionEvaluatorImpl;
+import com.adobe.cq.dam.download.api.DownloadTarget;
+import com.adobe.cq.wcm.spi.AssetDelivery;
+import io.wcm.testing.mock.aem.junit.AemContext;
+import org.apache.sling.commons.mime.MimeTypeService;
+import org.apache.sling.models.factory.ModelFactory;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AssetDeliveryRenditionDispatcherImplTest {
+    @Rule
+    public AemContext ctx = new AemContext();
+
+    @Mock
+    MimeTypeService mimeTypeService;
+
+    @Mock
+    DownloadTarget downloadTarget;
+
+    @Mock
+    ModelFactory modelFactory;
+
+    @Mock
+    AssetDelivery assetDelivery;
+
+    @Before
+    public void setUp() throws Exception {
+        ctx.load().json(getClass().getResourceAsStream("AssetDeliveryRenditionDispatcherImplTest.json"), "/content");
+
+        RequireAemMock.setAem(ctx,
+                RequireAem.Distribution.CLOUD_READY,
+                RequireAem.ServiceType.AUTHOR);
+
+        ctx.addModelsForClasses(AssetModelImpl.class);
+
+        MockAssetModels.mockModelFactory(ctx, modelFactory, "/content/dam/test.png");
+        MockAssetModels.mockModelFactory(ctx, modelFactory, "/content/dam/test.oft");
+
+        ctx.registerService(ModelFactory.class, modelFactory, org.osgi.framework.Constants.SERVICE_RANKING,
+                Integer.MAX_VALUE);
+
+
+        ctx.registerService(AssetDelivery.class, assetDelivery);
+        ctx.registerService(MimeTypeService.class, mimeTypeService);
+        ctx.registerService(ExpressionEvaluator.class, new ExpressionEvaluatorImpl());
+
+        ctx.registerInjectActivateService(new AssetRenditionsImpl());
+
+        ctx.registerInjectActivateService(new AssetDeliveryRenditionDispatcherImpl(), "rendition.mappings", new String[]{"test=foo"});
+    }
+
+    @Test
+    public void testAccepts_True() throws Exception {
+        ctx.currentResource("/content/dam/test.png");
+        AssetModel assetModel = ctx.request().adaptTo(AssetModel.class);
+
+        AssetRenditionDispatcher dispatcher = ctx.getService(AssetRenditionDispatcher.class);
+
+        assertTrue("PNG should be accepted", dispatcher.accepts(assetModel, "test"));
+    }
+
+    @Test
+    public void testAccepts_False() throws Exception {
+        ctx.currentResource("/content/dam/test.oft");
+        AssetModel assetModel = ctx.request().adaptTo(AssetModel.class);
+
+        AssetRenditionDispatcher dispatcher = ctx.getService(AssetRenditionDispatcher.class);
+
+        assertFalse("OFT should not be accepted", dispatcher.accepts(assetModel, "test"));
+    }
+}

--- a/core.cloud/src/test/java/com/adobe/aem/commons/assetshare/content/renditions/impl/dispatchers/AssetDeliveryRenditionDispatcherImplTest.java
+++ b/core.cloud/src/test/java/com/adobe/aem/commons/assetshare/content/renditions/impl/dispatchers/AssetDeliveryRenditionDispatcherImplTest.java
@@ -86,4 +86,26 @@ public class AssetDeliveryRenditionDispatcherImplTest {
 
         assertFalse("OFT should not be accepted", dispatcher.accepts(assetModel, "test"));
     }
+
+
+    @Test
+    public void testAccepts_NoDcFormat_False() {
+        ctx.currentResource("/content/dam/test.no-dc-format");
+        AssetModel assetModel = ctx.request().adaptTo(AssetModel.class);
+
+        AssetRenditionDispatcher dispatcher = ctx.getService(AssetRenditionDispatcher.class);
+
+        assertFalse("Missing dc:format should not be accepted", dispatcher.accepts(assetModel, "test"));
+    }
+
+
+    @Test
+    public void testAccepts_BlankDcFormat_False() {
+        ctx.currentResource("/content/dam/test.blank-dc-format");
+        AssetModel assetModel = ctx.request().adaptTo(AssetModel.class);
+
+        AssetRenditionDispatcher dispatcher = ctx.getService(AssetRenditionDispatcher.class);
+
+        assertFalse("Blank dc:format should not be accepted", dispatcher.accepts(assetModel, "test"));
+    }
 }

--- a/core.cloud/src/test/resources/com/adobe/aem/commons/assetshare/content/renditions/impl/dispatchers/AssetDeliveryRenditionDispatcherImplTest.json
+++ b/core.cloud/src/test/resources/com/adobe/aem/commons/assetshare/content/renditions/impl/dispatchers/AssetDeliveryRenditionDispatcherImplTest.json
@@ -39,6 +39,45 @@
           }
         }
       }
+    },
+    "test.no-dc-format": {
+      "jcr:primaryType": "dam:Asset",
+      "jcr:content": {
+        "jcr:primaryType": "nt:unstructured",
+        "metadata": {
+          "jcr:primaryType": "nt:unstructured"
+        },
+        "renditions": {
+          "jcr:primaryType": "nt:unstructured",
+          "cq5dam.web.1280.1280.png": {
+            "jcr:primaryType": "nt:file",
+            "jcr:content": {
+              "jcr:primaryType": "oak:Resource",
+              "jcr:mimeType": "image/png"
+            }
+          }
+        }
+      }
+    },
+    "test.blank-dc-format": {
+      "jcr:primaryType": "dam:Asset",
+      "jcr:content": {
+        "jcr:primaryType": "nt:unstructured",
+        "metadata": {
+          "jcr:primaryType": "nt:unstructured",
+            "dc:format": " "
+        },
+        "renditions": {
+          "jcr:primaryType": "nt:unstructured",
+          "cq5dam.web.1280.1280.png": {
+            "jcr:primaryType": "nt:file",
+            "jcr:content": {
+              "jcr:primaryType": "oak:Resource",
+              "jcr:mimeType": "image/png"
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/core.cloud/src/test/resources/com/adobe/aem/commons/assetshare/content/renditions/impl/dispatchers/AssetDeliveryRenditionDispatcherImplTest.json
+++ b/core.cloud/src/test/resources/com/adobe/aem/commons/assetshare/content/renditions/impl/dispatchers/AssetDeliveryRenditionDispatcherImplTest.json
@@ -1,0 +1,44 @@
+{
+  "dam": {
+    "test.png": {
+      "jcr:primaryType": "dam:Asset",
+      "jcr:content": {
+        "jcr:primaryType": "nt:unstructured",
+        "metadata": {
+          "jcr:primaryType": "nt:unstructured",
+          "dc:format": "image/png"
+        },
+        "renditions": {
+          "jcr:primaryType": "nt:unstructured",
+          "cq5dam.web.1280.1280.png": {
+            "jcr:primaryType": "nt:file",
+            "jcr:content": {
+              "jcr:primaryType": "oak:Resource",
+              "jcr:mimeType": "image/png"
+            }
+          }
+        }
+      }
+    },
+    "test.oft": {
+      "jcr:primaryType": "dam:Asset",
+      "jcr:content": {
+        "jcr:primaryType": "nt:unstructured",
+        "metadata": {
+          "jcr:primaryType": "nt:unstructured",
+          "dc:format": "application/vnd.oasis.opendocument.text"
+        },
+        "renditions": {
+          "jcr:primaryType": "nt:unstructured",
+          "cq5dam.web.1280.1280.png": {
+            "jcr:primaryType": "nt:file",
+            "jcr:content": {
+              "jcr:primaryType": "oak:Resource",
+              "jcr:mimeType": "image/png"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -897,6 +897,12 @@ Bundle-DocURL: https://opensource.adobe.com/asset-share-commons/
         the ones for AEM on prem are always built -->
         <profile>
             <id>cloud</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>env.CM_BUILD</name>
+                </property>
+            </activation>
             <modules>
                 <module>core.cloud</module>
             </modules>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/video/templates/player.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/details/video/templates/player.html
@@ -37,21 +37,14 @@
 	       style="height:${height @ context = 'styleToken'}px;"
 	       controls controlsList="nodownload"
 	       data-sly-test.height="${properties['height']}">
-         	<source src="${video.src}" 
-          		type="video/webm"/>
-  		<source src="${video.src}"
-          		type="video/mp4"/>       
-               
+			<source src="${video.src}" />
         </video>
 
         <!--/* Video element without a max height */-->
         <video class="ui centered image cmp-image"
                poster="${properties['posterImage']}" controls controlsList="nodownload"
                data-sly-test="${!height}">
-        	<source src="${video.src}" 
-          		type="video/webm"/>
-  		<source src="${video.src}"
-          		type="video/mp4" />        
+        	<source src="${video.src}"/>
         </video>
 
 </template>

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/results/clientlibs/site/js.txt
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/results/clientlibs/site/js.txt
@@ -1,0 +1,3 @@
+#base=js
+
+scripts.js

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/results/clientlibs/site/js/scripts.js
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/results/clientlibs/site/js/scripts.js
@@ -1,0 +1,8 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const images = document.querySelectorAll('img[data-asset-share-missing-image]');
+    images.forEach(img => {
+        img.onerror = function() {
+            this.src = this.getAttribute('data-asset-share-missing-image');
+        };
+    });
+});

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/results/result/card/templates/card.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/results/result/card/templates/card.html
@@ -31,7 +31,7 @@
                  class="cmp-image--card"
                  width="237px"
                  height="175px"
-                 data-asset-share-missing-thumbnail="${properties['missingImage']}"
+                 data-asset-share-missing-image="${properties['missingImage']}"
                  alt="${asset.properties['title']}"/>
         </a>
 

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/results/result/card/templates/card.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/results/result/card/templates/card.html
@@ -31,6 +31,7 @@
                  class="cmp-image--card"
                  width="237px"
                  height="175px"
+                 data-asset-share-missing-thumbnail="${properties['missingImage']}"
                  alt="${asset.properties['title']}"/>
         </a>
 

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/results/result/horizontal-masonry-card/templates/card.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/results/result/horizontal-masonry-card/templates/card.html
@@ -32,7 +32,7 @@
         <a class="cmp-card__link" href="${assetDetails.url @ suffix = asset.path}">
             <img src="${asset.properties['rendition?name=card'] || properties['missingImage'] @ context = 'attribute'}"
                  class="cmp-card__image"
-                 data-asset-share-missing-thumbnail="${properties['missingImage']}"
+                 data-asset-share-missing-image="${properties['missingImage']}"
                  alt="${asset.properties['title']}"/>
         </a>
 

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/results/result/horizontal-masonry-card/templates/card.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/results/result/horizontal-masonry-card/templates/card.html
@@ -32,6 +32,7 @@
         <a class="cmp-card__link" href="${assetDetails.url @ suffix = asset.path}">
             <img src="${asset.properties['rendition?name=card'] || properties['missingImage'] @ context = 'attribute'}"
                  class="cmp-card__image"
+                 data-asset-share-missing-thumbnail="${properties['missingImage']}"
                  alt="${asset.properties['title']}"/>
         </a>
 

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/results/result/list/templates/list.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/results/result/list/templates/list.html
@@ -41,7 +41,7 @@
 		<td class="image">
 			<a href="${assetDetails.fullUrl}"><img src="${asset.properties['rendition?name=list'] || properties['missingImage'] @ context = 'attribute'}"
 												   width="98px"
-												   data-assets-share-missing-thumbnail="${properties['missingImage']}"
+												   data-assets-share-missing-image="${properties['missingImage']}"
 												   alt="${asset.properties['title']}"/></a>
 		</td>
 		<td class="header">

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/results/result/list/templates/list.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/results/result/list/templates/list.html
@@ -41,6 +41,7 @@
 		<td class="image">
 			<a href="${assetDetails.fullUrl}"><img src="${asset.properties['rendition?name=list'] || properties['missingImage'] @ context = 'attribute'}"
 												   width="98px"
+												   data-assets-share-missing-thumbnail="${properties['missingImage']}"
 												   alt="${asset.properties['title']}"/></a>
 		</td>
 		<td class="header">


### PR DESCRIPTION
Fixed issue in AssetDelivery dispatcher where it would NPE if the dc:format property was not set on an asset (which appears to be the case for OFT files).

Also, added JS fallback support for imgs that dont load (to use the missing image, cliend-side).


![2024-07-22 at 4 55 PM](https://github.com/user-attachments/assets/7216de10-32c9-43cc-8e00-9703f7dbeb6e)

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
