### PR TITLE
Update ContentTypeImpl.java

### DIFF
--- a/core/src/main/java/com/adobe/aem/commons/assetshare/content/properties/impl/ContentTypeImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/content/properties/impl/ContentTypeImpl.java
@@ -67,7 +67,7 @@ public class ContentTypeImpl extends AbstractComputedProperty<String> {
     private static final Map<String, String> mimeTypeToLabelMap = ImmutableMap.<String, String>builder()
             .put("image/vnd.adobe.photoshop",                                                   "Photoshop")
             .put("application/msword",                                                          "Word Doc")
-            .put("application//vnd.openxmlformats-officedocument.wordprocessingml.document",    "Word Doc")
+            .put("application/vnd.openxmlformats-officedocument.wordprocessingml.document",    "Word Doc")
             .put("application/vnd.ms-excel",                                                    "Excel")
             .put("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",           "Excel")
             .put("application/vnd.ms-powerpoint",                                               "PowerPoint")


### PR DESCRIPTION
As mentioned in 

https://github.com/adobe/asset-share-commons/issues/1204

The Word Doc mimeType has an extra slash.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
