### PR TITLE
Removed use of com.google.common

### DIFF
--- a/core.cloud/src/main/java/com/adobe/aem/commons/assetshare/content/renditions/impl/dispatchers/AssetDeliveryRenditionDispatcherImpl.java
+++ b/core.cloud/src/main/java/com/adobe/aem/commons/assetshare/content/renditions/impl/dispatchers/AssetDeliveryRenditionDispatcherImpl.java
@@ -26,7 +26,6 @@ import com.adobe.aem.commons.assetshare.util.RequireAem;
 import com.adobe.cq.wcm.spi.AssetDelivery;
 import com.day.cq.dam.api.Asset;
 import com.day.cq.dam.api.DamConstants;
-import com.google.common.base.Splitter;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.NameValuePair;
@@ -257,7 +256,10 @@ public class AssetDeliveryRenditionDispatcherImpl extends AbstractRenditionDispa
     }
 
     protected String getDeliveryURL(String expression, Asset asset) {
-        final Map<String, String> map = Splitter.on("&").withKeyValueSeparator("=").split(expression);
+        final Map<String, String> map = Arrays.stream(expression.split("&"))
+                .map(s -> s.split("=", 2))
+                .filter(arr -> arr.length == 2)
+                .collect(Collectors.toMap(arr -> arr[0], arr -> arr[1]));
         final Map<String, Object> params = map.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue()));
 
         // The following properties are REQUIRED by the AssetDelivery service, so add them with defaults if they do not exist

--- a/core.cloud/src/test/java/com/adobe/aem/commons/assetshare/content/renditions/impl/dispatchers/AssetDeliveryRenditionDispatcherImplTest.java
+++ b/core.cloud/src/test/java/com/adobe/aem/commons/assetshare/content/renditions/impl/dispatchers/AssetDeliveryRenditionDispatcherImplTest.java
@@ -131,7 +131,6 @@ public class AssetDeliveryRenditionDispatcherImplTest {
 
         Asset asset = ctx.create().asset("/content/dam/test.png", 100, 100, "image/png");
         String expression = "format=webp&seoname=test-asset";
-        when(assetDelivery.getDeliveryURL(eq(null), any())).thenReturn(null);
 
         String result = dispatcher.getDeliveryURL(expression, asset);
 


### PR DESCRIPTION
Replaced use of com.google.common Splitter with vanilla Java implemtation.

## Related Issue

Fixes #1241

## Motivation and Context

Google lib is deprecated.

## How Has This Been Tested?

Unit test


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
