### PR TITLE
#1250 - Relaxed imports to support AEM 6.5 SP19

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -122,6 +122,11 @@ com.adobe.aem.commons.assetshare.content.impl,\
 com.adobe.aem.commons.assetshare.search.impl,\
 com.adobe.aem.commons.assetshare.search.results.impl.result,\
 com.adobe.aem.commons.assetshare.util.impl
+Import-Package: \
+    com.adobe.cq.wcm.core.components.models.form;version="[14.2.0,15)",\
+    com.day.cq.dam.commons.util;version="[1.61.0,3)",\
+    org.apache.commons.lang3;version="[3.12.0,4)",\
+    *
                      ]]></bnd>
                 </configuration>
             </plugin>


### PR DESCRIPTION
FIxed #1250 - Relaxes certain imports required by AEM 6.5 SP18.

The newer package versions do change the functionality used by ASC.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
