### PR TITLE
Changed For loop in modal.js to use ES5-friendly syntax

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/download/clientlibs/site/js/download.js
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/modals/download/clientlibs/site/js/download.js
@@ -54,8 +54,9 @@ jQuery((function(ns, semanticModal, licenseModal, downloadService) {
                     beforeShow: function(htmlResponse, modalTracker) {
                         var modal = $("<div>" + htmlResponse + "</div>").find(ns.Elements.selector(getId()));
                         if($(modal).data(DOWNLOAD_DIRECT)) {
-                            for(var modalId of modalTracker) {
-                                if(modalId !== licenseModal.id()) {
+                            for (var i = 0; i < modalTracker.length; i++) {
+                                var modalId = modalTracker[i];
+                                if (modalId !== licenseModal.id()) {
                                     ns.Elements.element(modalId).modal('hide');
                                 }
                             }


### PR DESCRIPTION
Fixes issue described in #1267 where the for loop is using ES6 syntax that AEM clientlib compiler doesnt like.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
