### PR TITLE
fix for ASC issue #1276 - modals not opening correctly when ASC loaded in iframe

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-site/js/semantic-ui/modal.js
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-site/js/semantic-ui/modal.js
@@ -24,7 +24,7 @@ AssetShare.SemanticUI.Modal = (function ($, ns) {
     var tracker = [];
 
     function isPreviewMode() {
-        var topWindow = $(window.top);
+        var topWindow = ns.Util.isSameOrigin() ? $(window.top) : $(window);
 
         return topWindow.length > 0 &&
             topWindow[0].Granite &&


### PR DESCRIPTION
Fix bug with modals not appearing correctly when ASC loaded into an iFrame.

## Description

The browser throws a `SecurityError` when the js code tries to access properties of `window.top`, which is not accessible to javascript loaded in an iframe as `window.top` will point to a parent window. This fix reuses the `ns.Util.isSameOrigin()`  function to check if `window.top` will be allowed, and falls back to using the current window if not.

## Related Issue
#1276 

## Motivation and Context

We would like to host an ASC site within an iframe embed.

## How Has This Been Tested?

Tested fix in cross-domain iframe setting and fix seems to resolve issue.

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
