### PR TITLE
Added support for AI Search in AEM as a Cloud Service

### DIFF
--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/FulltextPredicateImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/predicates/impl/FulltextPredicateImpl.java
@@ -21,6 +21,7 @@ package com.adobe.aem.commons.assetshare.components.predicates.impl;
 
 import com.adobe.aem.commons.assetshare.components.predicates.AbstractPredicate;
 import com.adobe.aem.commons.assetshare.components.predicates.FulltextPredicate;
+import com.adobe.aem.commons.assetshare.search.impl.predicateevaluators.AiFulltextPredicateEvaluator;
 import com.adobe.aem.commons.assetshare.util.PredicateUtil;
 import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.export.json.ExporterConstants;
@@ -29,10 +30,12 @@ import com.day.cq.search.eval.FulltextPredicateEvaluator;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.wrappers.ValueMapDecorator;
+import org.apache.sling.models.annotations.Default;
 import org.apache.sling.models.annotations.Exporter;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.Required;
 import org.apache.sling.models.annotations.injectorspecific.Self;
+import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
 
 import javax.annotation.Nonnull;
 import javax.annotation.PostConstruct;
@@ -56,6 +59,10 @@ public class FulltextPredicateImpl extends AbstractPredicate implements Fulltext
     @Self
     @Required
     private Text coreText;
+
+    @ValueMapValue(name = "aiSearch")
+    @Default(booleanValues = false)
+    private boolean aiSearch;
 
     @PostConstruct
     protected void init() {
@@ -104,7 +111,11 @@ public class FulltextPredicateImpl extends AbstractPredicate implements Fulltext
 
     @Override
     public String getName() {
-        return FulltextPredicateEvaluator.FULLTEXT;
+        if (aiSearch) {
+            return AiFulltextPredicateEvaluator.PREDICATE_NAME;
+        } else {
+            return FulltextPredicateEvaluator.FULLTEXT;
+        }
     }
 
     @Override

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/search/impl/predicateevaluators/AiFulltextPredicateEvaluator.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/search/impl/predicateevaluators/AiFulltextPredicateEvaluator.java
@@ -1,0 +1,126 @@
+/*
+ * Asset Share Commons
+ *
+ * Copyright (C) 2018 Adobe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.adobe.aem.commons.assetshare.search.impl.predicateevaluators;
+
+import com.adobe.aem.commons.assetshare.util.RequireAem;
+import com.day.cq.search.Predicate;
+import com.day.cq.search.eval.EvaluationContext;
+import com.day.cq.search.eval.FulltextPredicateEvaluator;
+import com.day.cq.search.eval.PredicateEvaluator;
+import com.day.cq.search.facets.FacetExtractor;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+
+import javax.jcr.query.Row;
+import java.util.*;
+
+import static java.util.Collections.emptyList;
+
+/**
+ * This is a wrapper about the AEM OOTB FulltextPredicateEvaluator that adds AI Search support
+ */
+@Component(
+        service = { PredicateEvaluator.class },
+        factory = "com.day.cq.search.eval.PredicateEvaluator/" + AiFulltextPredicateEvaluator.PREDICATE_NAME
+)
+public class AiFulltextPredicateEvaluator implements PredicateEvaluator {
+    private static final Logger log = org.slf4j.LoggerFactory.getLogger(AiFulltextPredicateEvaluator.class);
+
+    @Reference(target = "(distribution=cloud-ready)")
+    RequireAem requireAem;
+
+    private static final String AI_SEARCH_TOKEN = System.getProperty("com.adobe.granite.omnisearch.inference.query.prefix", "?{}?");
+
+    public static final String PREDICATE_NAME = "ai-" + FulltextPredicateEvaluator.FULLTEXT;
+
+    protected static final String PREDICATE_BUILT_KEY = "__asset-share-commons--predicate-built";
+    protected static final String PREDICATE_BUILT_VALUE = "true";
+
+    private PredicateEvaluator fulltextEvaluator = new FulltextPredicateEvaluator();
+
+    protected Predicate buildPredicate(final Predicate predicate) {
+        if (PREDICATE_BUILT_VALUE.equals(predicate.get(PREDICATE_BUILT_KEY))) {
+            return predicate;
+        }
+
+        String value = predicate.get(PREDICATE_NAME, "");
+
+        if (AiSearchRenderCondition.isAiSearchEnabled() && !StringUtils.isBlank(value)) {
+            value = AI_SEARCH_TOKEN.concat(value);
+        }
+
+        predicate.set(FulltextPredicateEvaluator.FULLTEXT, value);
+        predicate.set(PREDICATE_NAME, null);
+        predicate.set(PREDICATE_BUILT_KEY, PREDICATE_BUILT_VALUE);
+
+        return predicate;
+    }
+
+    protected PredicateEvaluator getPredicateEvaluator(Predicate predicate) {
+        return fulltextEvaluator;
+    }
+
+    @Override
+    public String getXPathExpression(Predicate predicate, EvaluationContext evaluationContext) {
+        return getPredicateEvaluator(predicate).getXPathExpression(buildPredicate(predicate), evaluationContext);
+    }
+
+    @Override
+    public boolean includes(final Predicate predicate, final Row row, final EvaluationContext evaluationContext) {
+        return getPredicateEvaluator(predicate).includes(buildPredicate(predicate), row, evaluationContext);
+    }
+
+    @Override
+    public boolean canXpath(final Predicate predicate, final EvaluationContext evaluationContext) {
+        return getPredicateEvaluator(predicate).canXpath(buildPredicate(predicate), evaluationContext);
+    }
+
+    @Override
+    public boolean canFilter(final Predicate predicate, final EvaluationContext evaluationContext) {
+        return getPredicateEvaluator(predicate).canFilter(buildPredicate(predicate), evaluationContext);
+    }
+
+    @Override
+    public boolean isFiltering(final Predicate predicate, final EvaluationContext evaluationContext) {
+        throw new UnsupportedOperationException("isFiltering(..) is deprecated.");
+    }
+
+    @Override
+    public String[] getOrderByProperties(Predicate predicate, EvaluationContext evaluationContext) {
+        return getPredicateEvaluator(predicate).getOrderByProperties(buildPredicate(predicate), evaluationContext);
+    }
+
+    @Override
+    public Comparator<Row> getOrderByComparator(Predicate predicate, EvaluationContext evaluationContext) {
+        return getPredicateEvaluator(predicate).getOrderByComparator(buildPredicate(predicate), evaluationContext);
+    }
+
+    @Override
+    public FacetExtractor getFacetExtractor(Predicate predicate, EvaluationContext evaluationContext) {
+        return getPredicateEvaluator(predicate).getFacetExtractor(buildPredicate(predicate), evaluationContext);
+    }
+}
+
+
+
+

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/search/impl/predicateevaluators/AiSearchRenderCondition.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/search/impl/predicateevaluators/AiSearchRenderCondition.java
@@ -1,0 +1,72 @@
+/*
+ * Asset Share Commons
+ *
+ * Copyright (C) 2018 Adobe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.adobe.aem.commons.assetshare.search.impl.predicateevaluators;
+
+import com.adobe.aem.commons.assetshare.util.RequireAem;
+import com.adobe.granite.ui.components.rendercondition.RenderCondition;
+import com.adobe.granite.ui.components.rendercondition.SimpleRenderCondition;
+import com.day.cq.search.Predicate;
+import com.day.cq.search.eval.EvaluationContext;
+import com.day.cq.search.eval.FulltextPredicateEvaluator;
+import com.day.cq.search.eval.PredicateEvaluator;
+import com.day.cq.search.facets.FacetExtractor;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.servlets.ServletResolverConstants;
+import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+
+import javax.jcr.query.Row;
+import javax.servlet.Servlet;
+import javax.servlet.ServletException;
+import java.io.IOException;
+import java.util.Comparator;
+
+/**
+ * This is a wrapper about the AEM OOTB FulltextPredicateEvaluator that adds AI Search support
+ */
+@Component(
+        service = { Servlet.class },
+        property = {
+                ServletResolverConstants.SLING_SERVLET_METHODS + "=GET",
+                ServletResolverConstants.SLING_SERVLET_RESOURCE_TYPES + "=asset-share-commons/authoring/renderconditions/ai-search"
+        }
+)
+public class AiSearchRenderCondition extends SlingSafeMethodsServlet {
+    private static final Logger log = org.slf4j.LoggerFactory.getLogger(AiSearchRenderCondition.class);
+
+    public static boolean isAiSearchEnabled() {
+        String inferenceEnabledStr = System.getProperty("oak.query.InferenceEnabled");
+        boolean inferenceEnabled = inferenceEnabledStr != null && Boolean.parseBoolean(inferenceEnabledStr) == Boolean.TRUE;
+        return inferenceEnabled;
+    }
+
+    protected void doGet(SlingHttpServletRequest request, SlingHttpServletResponse response)
+            throws ServletException, IOException {
+        request.setAttribute(RenderCondition.class.getName(), new SimpleRenderCondition(isAiSearchEnabled()));
+    }
+}
+
+
+
+

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/search/impl/predicateevaluators/PropertyValuesPredicateEvaluator.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/search/impl/predicateevaluators/PropertyValuesPredicateEvaluator.java
@@ -49,7 +49,7 @@ import java.util.stream.Stream;
 import static java.util.Collections.emptyList;
 
 /**
- * The QueryBuilder predicate for this Sample would be structured like so...
+ * The QueryBuilder predicate for this Predicate Evaluator would be structured like so...
  * <p>
  * type=cq:PageContent<br>
  * path=/content<br>

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/search/providers/impl/QuerySearchProviderImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/search/providers/impl/QuerySearchProviderImpl.java
@@ -90,6 +90,13 @@ public class QuerySearchProviderImpl implements SearchProvider {
         return true;
     }
 
+    /**
+     *
+     * @param request
+     * @return
+     * @throws UnsafeSearchException
+     * @throws RepositoryException
+     */
     public Results getResults(final SlingHttpServletRequest request) throws UnsafeSearchException, RepositoryException {
         final ResourceResolver resourceResolver = request.getResourceResolver();
 
@@ -195,6 +202,13 @@ public class QuerySearchProviderImpl implements SearchProvider {
         return params;
     }
 
+    /**
+     * Checks if the request parameters contain paths that are allowed by the Page Predicate.
+     *
+     * @param pagePredicate the Page Predicate containing the allowed paths.
+     * @param requestParams the request parameters to check.
+     * @return true if at least one of the provided paths is allowed, false otherwise.
+     */
     private boolean isPathsProvidedByRequestParams(final PagePredicate pagePredicate, final Map<String, String> requestParams) {
         final ValueMap pathPredicates = PredicateUtil.findPredicate(requestParams, PathPredicateEvaluator.PATH, PathPredicateEvaluator.PATH);
 
@@ -219,6 +233,12 @@ public class QuerySearchProviderImpl implements SearchProvider {
         return hasAllowed;
     }
 
+
+    /**
+     * Remove unnecessary parameters that should not be passed to QueryBuilder.
+     *
+     * @param params the map of query parameters.
+     */
     private void cleanParams(Map<String, String> params) {
         // Do not allow users to specify guessTotal
         params.remove("p.guessTotal");
@@ -262,6 +282,11 @@ public class QuerySearchProviderImpl implements SearchProvider {
         return merged;
     }
 
+    /**
+     * Debugging method to log the QueryBuilder parameters before the query is executed.
+     *
+     * @param predicateGroup the PredicateGroup containing the QueryBuilder parameters.
+     */
     private void debugPreQuery(PredicateGroup predicateGroup) {
         if (log.isDebugEnabled()) {
 
@@ -277,6 +302,11 @@ public class QuerySearchProviderImpl implements SearchProvider {
         }
     }
 
+    /**
+     * Debugging method to log the QueryBuilder results after the query is executed.
+     *
+     * @param searchResult the query results
+     */
     private void debugPostQuery(SearchResult searchResult) {
         if (log.isDebugEnabled()) {
             log.debug("Executed query statement:\n{}", searchResult.getQueryStatement());

--- a/core/src/test/java/com/adobe/aem/commons/assetshare/search/impl/predicateevaluators/AiFulltextPredicateEvaluatorTest.java
+++ b/core/src/test/java/com/adobe/aem/commons/assetshare/search/impl/predicateevaluators/AiFulltextPredicateEvaluatorTest.java
@@ -1,0 +1,73 @@
+package com.adobe.aem.commons.assetshare.search.impl.predicateevaluators;
+
+import com.day.cq.search.Predicate;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class AiFulltextPredicateEvaluatorTest {
+    private static final Object LOCK = new Object();
+
+    @Before
+    public void setUp() throws Exception {
+    }
+
+
+    @After
+    public void tearDown() throws Exception {
+        System.clearProperty("oak.query.InferenceEnabled");
+    }
+
+    @Test
+    public void buildPredicate_enabled() {
+        synchronized (LOCK) {
+            System.setProperty("oak.query.InferenceEnabled", "true");
+
+            AiFulltextPredicateEvaluator evaluator = new AiFulltextPredicateEvaluator();
+            Predicate predicate = new Predicate(AiFulltextPredicateEvaluator.PREDICATE_NAME);
+            predicate.set(AiFulltextPredicateEvaluator.PREDICATE_NAME, "test");
+
+            Predicate builtPredicate = evaluator.buildPredicate(predicate);
+
+            assertEquals("?{}?test", builtPredicate.get("fulltext"));
+            assertNull(builtPredicate.get(AiFulltextPredicateEvaluator.PREDICATE_NAME));
+            assertEquals(AiFulltextPredicateEvaluator.PREDICATE_BUILT_VALUE, builtPredicate.get(AiFulltextPredicateEvaluator.PREDICATE_BUILT_KEY));
+        }
+    }
+
+    @Test
+    public void buildPredicate_disabledNotSet() {
+        synchronized (LOCK) {
+            System.clearProperty("oak.query.InferenceEnabled");
+
+            AiFulltextPredicateEvaluator evaluator = new AiFulltextPredicateEvaluator();
+            Predicate predicate = new Predicate(AiFulltextPredicateEvaluator.PREDICATE_NAME);
+            predicate.set(AiFulltextPredicateEvaluator.PREDICATE_NAME, "test");
+
+            Predicate builtPredicate = evaluator.buildPredicate(predicate);
+
+            assertEquals("test", builtPredicate.get("fulltext"));
+            assertNull(builtPredicate.get(AiFulltextPredicateEvaluator.PREDICATE_NAME));
+            assertEquals(AiFulltextPredicateEvaluator.PREDICATE_BUILT_VALUE, builtPredicate.get(AiFulltextPredicateEvaluator.PREDICATE_BUILT_KEY));
+        }
+    }
+
+    @Test
+    public void buildPredicate_disabledFalse() {
+        synchronized (LOCK) {
+            System.setProperty("oak.query.InferenceEnabled", "false");
+
+            AiFulltextPredicateEvaluator evaluator = new AiFulltextPredicateEvaluator();
+            Predicate predicate = new Predicate(AiFulltextPredicateEvaluator.PREDICATE_NAME);
+            predicate.set(AiFulltextPredicateEvaluator.PREDICATE_NAME, "test");
+
+            Predicate builtPredicate = evaluator.buildPredicate(predicate);
+
+            assertEquals("test", builtPredicate.get("fulltext"));
+            assertNull(builtPredicate.get(AiFulltextPredicateEvaluator.PREDICATE_NAME));
+            assertEquals(AiFulltextPredicateEvaluator.PREDICATE_BUILT_VALUE, builtPredicate.get(AiFulltextPredicateEvaluator.PREDICATE_BUILT_KEY));
+        }
+    }
+}

--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/search-bar/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/search-bar/_cq_dialog/.content.xml
@@ -40,6 +40,17 @@
                                 jcr:primaryType="nt:unstructured"
                                 sling:resourceType="granite/ui/components/coral/foundation/container">
                                 <items jcr:primaryType="nt:unstructured">
+                                    <ai-search
+                                            jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                            name="./aiSearch"
+                                            fieldDescription="Enable AI search for full-text search. Your AEM as a Cloud Service program must be enabled for AI Search for this work."
+                                            text="Enable AI Search"
+                                            value="true">
+                                        <granite:rendercondition
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="asset-share-commons/authoring/renderconditions/ai-search"/>
+                                    </ai-search>
                                     <field-type
                                         jcr:primaryType="nt:unstructured"
                                         sling:resourceType="granite/ui/components/coral/foundation/form/hidden"


### PR DESCRIPTION
Add support for AI Search in AEM as a Cloud Service.

Only display the toggle when the AEM is enabled to evaluate AI fulltext search requests.

## Description

1. Added a checkbox on the Search Bar dialog to enable AI Search
2. Created a AIFulltextSearchPredicate for querybuilder 
3. Toggle its use in the search-bar component based on if AI Search is enabled. If not enabled, it falls back to regular Fulltext predicate.

## Motivation and Context

OOTB support for AEM as a Cloud Service AI Search in ASC.

## How Has This Been Tested?

AEM SDK and AEM s a Cloud Service sandbox.

## Screenshots (if appropriate):

<img width="1336" height="1095" alt="2025-07-21 at 3 17 PM" src="https://github.com/user-attachments/assets/959333b8-64e8-4c3a-8c56-0130d824ec92" />


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
