### PR TITLE
Support page editor with context path

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-author/js/authoring.js
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/clientlibs/clientlib-author/js/authoring.js
@@ -18,5 +18,5 @@
 
 /*global Granite */
 if (Granite && Granite.author && Granite.author.EditorFrame) {
-    Granite.author.EditorFrame.editorVanityRegex = /^\/editor(?!html)[a-z-A-Z0-9\.-_]*?html\//;
+    Granite.author.EditorFrame.editorVanityRegex = /^(.*?\/)(editor)(?!html)[a-z-A-Z0-9\.-_]*?html\//;
 }


### PR DESCRIPTION
Fixes #1292

Support PageEditor when a context path set; 

For example `author.com/foo-bar/editor.html/....`

It currently assumes the editor.html is loaded from the domain root (`author.com/editor.html/...`) which is the default behavior.

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
