### PR TITLE
Update AssetDetails404Servlet.java

### DIFF
--- a/core/src/main/java/com/adobe/aem/commons/assetshare/configuration/impl/AssetDetails404Servlet.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/configuration/impl/AssetDetails404Servlet.java
@@ -51,7 +51,8 @@ public class AssetDetails404Servlet extends SlingSafeMethodsServlet implements O
     protected final void doGet(SlingHttpServletRequest request, SlingHttpServletResponse response)
             throws ServletException, IOException {
         // Control which requests enter this method via acceptedByAssetRenditionDispatcher(..) below.
-        //send 404 error to let Sling handle it.
+        // Send 404 error to let Sling handle it.
+        response.setContentType("text/html;charset=UTF-8");
         response.sendError(SlingHttpServletResponse.SC_NOT_FOUND);
     }
 


### PR DESCRIPTION
Ensure the response content-type is set to text/html

Servlet path include stack information: (Servlet, content header change, nr of occurances in 7 days)

```
BundledScriptServlet (/libs/cq/Page/Page.jsp)#2 -> com.adobe.aem.commons.assetshare.configuration.impl.AssetDetails404Servlet#1 -> BundledScriptServlet (/libs/cq/Page/Page.jsp)#0	null to text/html	73
com.adobe.aem.commons.assetshare.configuration.impl.AssetDetails404Servlet#1 -> /libs/cq/Page/Page.jsp#0	null to text/html	51
com.adobe.aem.commons.assetshare.configuration.impl.AssetDetails404Servlet#1 -> BundledScriptServlet (/libs/cq/Page/Page.jsp)#0	null to text/html	9896
```

This can result in XSS attacks.


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
