### PR TITLE
Fix #1370 - Use principal-based ACL for asset-share-commons-mimetype-…

### DIFF
--- a/ui.config/src/main/content/jcr_root/apps/asset-share-commons/osgiconfig/config/org.apache.sling.jcr.repoinit.RepositoryInitializer-asset-share-commons-all.config
+++ b/ui.config/src/main/content/jcr_root/apps/asset-share-commons/osgiconfig/config/org.apache.sling.jcr.repoinit.RepositoryInitializer-asset-share-commons-all.config
@@ -2,7 +2,12 @@ scripts=["
 create service user asset-share-commons-email-service
 
 create service user asset-share-commons-mimetype-service
-set ACL for asset-share-commons-mimetype-service
+
+remove ACE for asset-share-commons-mimetype-service
+    allow jcr:read on /libs/dam/gui/content/assets/jcr:content/mimeTypeLookup
+end
+
+set principal ACL for asset-share-commons-mimetype-service
     allow jcr:read on /libs/dam/gui/content/assets/jcr:content/mimeTypeLookup
 end
 


### PR DESCRIPTION
…service

Resource-based ACLs create a rep:policy child node on the granted path. Since UIHelper.lookupMimeType blindly iterates and reads a mimetypes property off every child of mimeTypeLookup, the rep:policy node caused a NullPointerException whenever DITA files triggered OOTB DAM UI mimetype lookups. Switching to a principal-based ACL keeps the grant off the resource tree, and a remove ACE statement cleans up the stale rep:policy left behind on environments that already ran the old script.

## Related Issue

Fixes #1370 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
