### PR TITLE
Fix CWE-113: strip CR/LF from values written into HTTP response headers

### DIFF
--- a/core.cloud/src/main/java/com/adobe/aem/commons/assetshare/content/renditions/impl/dispatchers/AssetDeliveryRenditionDispatcherImpl.java
+++ b/core.cloud/src/main/java/com/adobe/aem/commons/assetshare/content/renditions/impl/dispatchers/AssetDeliveryRenditionDispatcherImpl.java
@@ -22,6 +22,7 @@ package com.adobe.aem.commons.assetshare.content.renditions.impl.dispatchers;
 import com.adobe.aem.commons.assetshare.content.AssetModel;
 import com.adobe.aem.commons.assetshare.content.renditions.*;
 import com.adobe.aem.commons.assetshare.util.ExpressionEvaluator;
+import com.adobe.aem.commons.assetshare.util.HttpHeaderUtil;
 import com.adobe.aem.commons.assetshare.util.RequireAem;
 import com.adobe.cq.wcm.spi.AssetDelivery;
 import com.day.cq.dam.api.Asset;
@@ -170,7 +171,7 @@ public class AssetDeliveryRenditionDispatcherImpl extends AbstractRenditionDispa
                 response.setStatus(HttpServletResponse.SC_MOVED_PERMANENTLY);
             }
 
-            response.setHeader("Location", renditionRedirect);
+            response.setHeader("Location", HttpHeaderUtil.sanitize(renditionRedirect));
 
         } else {
             log.error("Could not convert [ {} ] into a valid URI", renditionRedirect);

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/content/renditions/download/impl/AssetRenditionsZipperImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/content/renditions/download/impl/AssetRenditionsZipperImpl.java
@@ -23,6 +23,7 @@ import com.adobe.aem.commons.assetshare.content.AssetModel;
 import com.adobe.aem.commons.assetshare.content.renditions.download.AssetRenditionStreamer;
 import com.adobe.aem.commons.assetshare.content.renditions.download.AssetRenditionsDownloadOrchestrator;
 import com.adobe.aem.commons.assetshare.content.renditions.download.AssetRenditionsException;
+import com.adobe.aem.commons.assetshare.util.HttpHeaderUtil;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jackrabbit.vault.packaging.JcrPackage;
@@ -87,7 +88,7 @@ public class AssetRenditionsZipperImpl implements AssetRenditionsDownloadOrchest
                         final SlingHttpServletResponse response,
                         final List<AssetModel> assets,
                         final List<String> renditionNames) throws IOException {
-        final String filename = StringUtils.defaultIfBlank(getFileName(request.getResource().getValueMap()), DEFAULT_FILE_ATTACHMENT_NAME);
+        final String filename = HttpHeaderUtil.sanitize(StringUtils.defaultIfBlank(getFileName(request.getResource().getValueMap()), DEFAULT_FILE_ATTACHMENT_NAME));
 
         response.setHeader("Content-Disposition", "attachment; filename=\"" + filename + "\"");
         response.setContentType(JcrPackage.MIME_TYPE);

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/content/renditions/impl/AssetRenditionServlet.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/content/renditions/impl/AssetRenditionServlet.java
@@ -23,6 +23,7 @@ import com.adobe.aem.commons.assetshare.content.AssetModel;
 import com.adobe.aem.commons.assetshare.content.renditions.AssetRenditionDispatcher;
 import com.adobe.aem.commons.assetshare.content.renditions.AssetRenditionDispatchers;
 import com.adobe.aem.commons.assetshare.content.renditions.AssetRenditionParameters;
+import com.adobe.aem.commons.assetshare.util.HttpHeaderUtil;
 import com.adobe.aem.commons.assetshare.util.ServletHelper;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -159,10 +160,12 @@ public class AssetRenditionServlet extends SlingSafeMethodsServlet {
     }
 
     protected void setResponseHeaders(final SlingHttpServletResponse response, final AssetRenditionParameters parameters) {
+        final String fileName = HttpHeaderUtil.sanitize(parameters.getFileName());
+
         if (parameters.isDownload()) {
-            response.setHeader("Content-Disposition", String.format("attachment; filename=%s", parameters.getFileName()));
+            response.setHeader("Content-Disposition", String.format("attachment; filename=%s", fileName));
         } else {
-            response.setHeader("Content-Disposition", String.format("filename=%s", parameters.getFileName()));
+            response.setHeader("Content-Disposition", String.format("filename=%s", fileName));
         }
     }
 

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/content/renditions/impl/dispatchers/StaticRenditionDispatcherImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/content/renditions/impl/dispatchers/StaticRenditionDispatcherImpl.java
@@ -23,6 +23,7 @@ import com.adobe.aem.commons.assetshare.content.AssetModel;
 import com.adobe.aem.commons.assetshare.content.renditions.*;
 import com.adobe.aem.commons.assetshare.content.renditions.download.DownloadExtensionResolver;
 import com.adobe.aem.commons.assetshare.content.renditions.download.impl.AssetRenditionDownloadRequest;
+import com.adobe.aem.commons.assetshare.util.HttpHeaderUtil;
 import com.day.cq.dam.api.Asset;
 import com.day.cq.dam.api.DamConstants;
 import com.day.cq.dam.api.Rendition;
@@ -145,7 +146,7 @@ public class StaticRenditionDispatcherImpl extends AbstractRenditionDispatcherIm
                 assetRenditionTracker.track(this, request, parameters, rendition.getPath());
             }
 
-            response.setHeader("Content-Type", rendition.getMimeType());
+            response.setHeader("Content-Type", HttpHeaderUtil.sanitize(rendition.getMimeType()));
 
             request.getRequestDispatcher(rendition.adaptTo(Resource.class)).include(
                    new AssetRenditionDownloadRequest(request,

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/util/HttpHeaderUtil.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/util/HttpHeaderUtil.java
@@ -1,0 +1,39 @@
+/*
+ * Asset Share Commons
+ *
+ * Copyright (C) 2026 Adobe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.adobe.aem.commons.assetshare.util;
+
+public class HttpHeaderUtil {
+
+    /**
+     * Strips CR and LF characters from a value that will be placed into an HTTP response header,
+     * preventing header/response-splitting injection when the value is sourced from editable
+     * content (ex. DAM asset metadata such as dc:title or dam:MimeType).
+     *
+     * @param value the candidate header value to sanitize.
+     * @return the value with all CR and LF characters removed, or null if value is null.
+     */
+    public static String sanitize(final String value) {
+        if (value == null) {
+            return null;
+        }
+
+        return value.replaceAll("[\\r\\n]", "");
+    }
+}

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/util/package-info.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/util/package-info.java
@@ -17,7 +17,7 @@
  *
  */
 
-@Version("1.16.0")
+@Version("1.17.0")
 package com.adobe.aem.commons.assetshare.util;
 
 import org.osgi.annotation.versioning.Version;


### PR DESCRIPTION
Content-Type, Content-Disposition, and Location headers were built from DAM asset metadata and other values without stripping control characters. Add HttpHeaderUtil.sanitize() and apply it at all four sink sites.

## Description

Fixes one of CWE-113 reported in #1310 
